### PR TITLE
(feat )Build strings for Intel based MacOS amd64

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -76,6 +76,13 @@ val buildOlcRtcDarwinArm64 = registerOlcRtcBuildTask(
     outputName = "olcrtc-darwin-arm64"
 )
 
+val buildOlcRtcDarwinAmd64 = registerOlcRtcBuildTask(
+    taskName = "buildOlcRtcDarwinAmd64",
+    goos = "darwin",
+    goarch = "amd64",
+    outputName = "olcrtc-darwin-amd64"
+)
+
 val buildOlcRtcWindowsAmd64 = registerOlcRtcBuildTask(
     taskName = "buildOlcRtcWindowsAmd64",
     goos = "windows",
@@ -106,6 +113,7 @@ val copyOlcRtcDataAssets = tasks.register<Copy>("copyOlcRtcDataAssets") {
 
 val desktopNativeAssetTasks = mutableListOf<Any>(
     buildOlcRtcDarwinArm64,
+    buildOlcRtcDarwinAmd64,
     buildOlcRtcWindowsAmd64,
     buildOlcRtcLinuxAmd64,
     buildOlcRtcLinuxArm64,
@@ -116,7 +124,10 @@ val hostDesktopNativeAssetTasks = mutableListOf<Any>(
 )
 
 when {
-    currentBuildOs.isMacOsX -> hostDesktopNativeAssetTasks.add(buildOlcRtcDarwinArm64)
+    currentBuildOs.isMacOsX -> when (hostDesktopArch) {
+        "amd64" -> hostDesktopNativeAssetTasks.add(buildOlcRtcDarwinAmd64)
+        "arm64" -> hostDesktopNativeAssetTasks.add(buildOlcRtcDarwinArm64)
+    }
     currentBuildOs.isWindows -> hostDesktopNativeAssetTasks.add(buildOlcRtcWindowsAmd64)
     currentBuildOs.isLinux -> when (hostDesktopArch) {
         "amd64" -> hostDesktopNativeAssetTasks.add(buildOlcRtcLinuxAmd64)

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -118,11 +118,9 @@ class DesktopVpnManager private constructor(
 
     private suspend fun checkConnectionOnce(location: LocationConfig): Long {
         val port = allocateLocalPort()
-        val binary = DesktopNativeAssets.resolveOlcRtcBinary()
         val ready = CompletableDeferred<Unit>()
         val bypassActiveLinuxTun = DesktopPaths.os == DesktopOs.Linux && _status.value is VpnStatus.Connected
-        val checkProcess = startOlcRtcProcess(
-            binary = binary,
+        val checkProcess = startOlcRtcProcessWithFallback(
             location = location,
             socksPort = port,
             ready = ready,
@@ -159,11 +157,9 @@ class DesktopVpnManager private constructor(
         }
 
         try {
-            val binary = DesktopNativeAssets.resolveOlcRtcBinary()
             val ready = CompletableDeferred<Unit>()
             val useLinuxTun = DesktopPaths.os == DesktopOs.Linux
-            process = startOlcRtcProcess(
-                binary = binary,
+            process = startOlcRtcProcessWithFallback(
                 location = location,
                 socksPort = PacServer.LOCAL_SOCKS_PORT,
                 ready = ready,
@@ -209,6 +205,36 @@ class DesktopVpnManager private constructor(
                 setStatus(VpnStatus.Error(e.message ?: "Desktop start failed"))
             }
         }
+    }
+
+    private fun startOlcRtcProcessWithFallback(
+        location: LocationConfig,
+        socksPort: Int,
+        ready: CompletableDeferred<Unit>,
+        logOutput: Boolean,
+        privileged: Boolean
+    ): Process {
+        val binaries = DesktopNativeAssets.resolveOlcRtcBinaryCandidates()
+        var lastException: Exception? = null
+
+        for (binary in binaries) {
+            try {
+                return startOlcRtcProcess(
+                    binary = binary,
+                    location = location,
+                    socksPort = socksPort,
+                    ready = ready,
+                    logOutput = logOutput,
+                    privileged = privileged
+                )
+            } catch (e: Exception) {
+                lastException = e
+                if (binary == binaries.last()) break
+                addLog("olcRTC start failed for ${binary.fileName}: ${e.message}. Retrying with fallback binary.")
+            }
+        }
+
+        throw lastException ?: error("olcRTC binary failed to start")
     }
 
     private suspend fun stopDesktopMode(finalStatus: Boolean) {

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopNativeAssets.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopNativeAssets.kt
@@ -10,12 +10,50 @@ import kotlin.io.path.exists
 
 internal object DesktopNativeAssets {
     fun resolveOlcRtcBinary(): Path {
-        val fileName = olcRtcFileName()
-        return resolveBinary(
-            fileName = fileName,
-            resourceName = "native/$fileName",
-            candidates = olcRtcSourceCandidates(fileName)
-        )
+        return resolveOlcRtcBinaryCandidates().first()
+    }
+
+    fun resolveOlcRtcBinaryCandidates(): List<Path> {
+        val fileNames = olcRtcFileNames()
+        return fileNames.mapNotNull { resolveOlcRtcBinaryOrNull(it) }.also {
+            if (it.isEmpty()) {
+                error("Bundled native binary is missing: ${fileNames.joinToString(", ") { name -> "native/$name" }}")
+            }
+        }
+    }
+
+    private fun resolveOlcRtcBinaryOrNull(fileName: String): Path? {
+        return try {
+            resolveBinary(
+                fileName = fileName,
+                resourceName = "native/$fileName",
+                candidates = olcRtcSourceCandidates(fileName)
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun olcRtcFileNames(): List<String> {
+        return when (DesktopPaths.os) {
+            DesktopOs.MacOS -> listOf(
+                "olcrtc-darwin-${desktopArch()}",
+                "olcrtc-darwin-${desktopArchFallback()}"
+            ).distinct()
+            DesktopOs.Windows -> listOf("olcrtc-windows-amd64.exe")
+            DesktopOs.Linux -> listOf("olcrtc-linux-${desktopArch()}")
+            DesktopOs.Other -> error("Olcbox desktop supports macOS, Windows and Linux")
+        }
+    }
+
+    private fun olcRtcFileName(): String = olcRtcFileNames().first()
+
+    private fun desktopArchFallback(): String {
+        return when (desktopArch()) {
+            "arm64" -> "amd64"
+            "amd64" -> "arm64"
+            else -> "amd64"
+        }
     }
 
     fun resolveOlcRtcDataDir(): Path {
@@ -78,15 +116,6 @@ internal object DesktopNativeAssets {
         }
 
         error("Bundled olcRTC data file is missing: $resourceName")
-    }
-
-    fun olcRtcFileName(): String {
-        return when (DesktopPaths.os) {
-            DesktopOs.MacOS -> "olcrtc-darwin-arm64"
-            DesktopOs.Windows -> "olcrtc-windows-amd64.exe"
-            DesktopOs.Linux -> "olcrtc-linux-${desktopArch()}"
-            DesktopOs.Other -> error("Olcbox desktop supports macOS, Windows and Linux")
-        }
     }
 
     fun hevSocks5TunnelFileName(): String {


### PR DESCRIPTION
**Description**
I noticed release section https://github.com/alananisimov/olcbox/releases includes installation files for ARM based devices and lacks media for amd64 (x86) architecture
This PR. modifies the following files in order to enable users build an app on their Intel based Mac computers:
- desktopApp/build.gradle.kts
- sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
- sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopNativeAssets.kt

**Test environment**
HW: Apple Macbook Pro A2141
OS: Apple MacOS X Tahoe 26.3.1 (25D2128)

**Confirmation**
<img width="500" height="500" alt="CleanShot 2026-05-09 at 17 59 08@2x" src="https://github.com/user-attachments/assets/b1aef9ae-c21a-4d8f-9bbe-e8e50fa3dc4e" />
