### PR TITLE
Codex/jitsi stable client

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -37,6 +37,7 @@ android {
         applicationId = "org.olcbox.app"
         versionCode = olcboxVersionCode.get()
         versionName = olcboxVersion.get()
+        manifestPlaceholders["appLabel"] = "Olcbox"
 
         ndk {
             abiFilters += listOf("arm64-v8a", "x86_64")
@@ -56,6 +57,10 @@ android {
 
     buildTypes {
         debug {
+            applicationIdSuffix = ".jitsi"
+            versionNameSuffix = "-jitsi"
+            manifestPlaceholders["appLabel"] = "Olcbox Jitsi"
+
             if (hasReleaseKeystore) {
                 signingConfig = signingConfigs.getByName("release")
             }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
     <application
         android:name=".App"
         android:icon="@mipmap/ic_launcher"
-        android:label="Olcbox"
+        android:label="${appLabel}"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@android:style/Theme.Material.NoActionBar"
         android:usesCleartextTraffic="true">

--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -42,6 +42,17 @@ fun desktopArchName(arch: String): String = when (arch.lowercase()) {
 fun shellQuote(value: String): String = "'${value.replace("'", "'\"'\"'")}'"
 
 val hostDesktopArch = desktopArchName(System.getProperty("os.arch"))
+val buildOlcRtcCgoLibraries = providers.gradleProperty("olcbox.buildOlcRtcCgo")
+    .orElse(providers.environmentVariable("OLCBOX_BUILD_OLCRTC_CGO"))
+    .map { value ->
+        when (value.lowercase()) {
+            "1", "true", "yes", "on" -> true
+            "0", "false", "no", "off" -> false
+            else -> error("olcbox.buildOlcRtcCgo/OLCBOX_BUILD_OLCRTC_CGO must be true or false")
+        }
+    }
+    .orElse(false)
+    .get()
 
 fun registerOlcRtcBuildTask(
     taskName: String,
@@ -185,40 +196,47 @@ val desktopNativeAssetTasks = mutableListOf<Any>(
     buildOlcRtcWindowsAmd64,
     buildOlcRtcLinuxAmd64,
     buildOlcRtcLinuxArm64,
-    buildOlcRtcLibDarwinArm64,
-    buildOlcRtcLibDarwinAmd64,
-    buildOlcRtcLibLinuxAmd64,
-    buildOlcRtcLibLinuxArm64,
-    buildOlcRtcLibWindowsAmd64,
     copyOlcRtcDataAssets
 )
 val hostDesktopNativeAssetTasks = mutableListOf<Any>(
     copyOlcRtcDataAssets
 )
 
+if (buildOlcRtcCgoLibraries) {
+    desktopNativeAssetTasks.addAll(
+        listOf(
+            buildOlcRtcLibDarwinArm64,
+            buildOlcRtcLibDarwinAmd64,
+            buildOlcRtcLibLinuxAmd64,
+            buildOlcRtcLibLinuxArm64,
+            buildOlcRtcLibWindowsAmd64
+        )
+    )
+}
+
 when {
     currentBuildOs.isMacOsX -> when (hostDesktopArch) {
         "amd64" -> {
             hostDesktopNativeAssetTasks.add(buildOlcRtcDarwinAmd64)
-            hostDesktopNativeAssetTasks.add(buildOlcRtcLibDarwinAmd64)
+            if (buildOlcRtcCgoLibraries) hostDesktopNativeAssetTasks.add(buildOlcRtcLibDarwinAmd64)
         }
         "arm64" -> {
             hostDesktopNativeAssetTasks.add(buildOlcRtcDarwinArm64)
-            hostDesktopNativeAssetTasks.add(buildOlcRtcLibDarwinArm64)
+            if (buildOlcRtcCgoLibraries) hostDesktopNativeAssetTasks.add(buildOlcRtcLibDarwinArm64)
         }
     }
     currentBuildOs.isWindows -> {
         hostDesktopNativeAssetTasks.add(buildOlcRtcWindowsAmd64)
-        hostDesktopNativeAssetTasks.add(buildOlcRtcLibWindowsAmd64)
+        if (buildOlcRtcCgoLibraries) hostDesktopNativeAssetTasks.add(buildOlcRtcLibWindowsAmd64)
     }
     currentBuildOs.isLinux -> when (hostDesktopArch) {
         "amd64" -> {
             hostDesktopNativeAssetTasks.add(buildOlcRtcLinuxAmd64)
-            hostDesktopNativeAssetTasks.add(buildOlcRtcLibLinuxAmd64)
+            if (buildOlcRtcCgoLibraries) hostDesktopNativeAssetTasks.add(buildOlcRtcLibLinuxAmd64)
         }
         "arm64" -> {
             hostDesktopNativeAssetTasks.add(buildOlcRtcLinuxArm64)
-            hostDesktopNativeAssetTasks.add(buildOlcRtcLibLinuxArm64)
+            if (buildOlcRtcCgoLibraries) hostDesktopNativeAssetTasks.add(buildOlcRtcLibLinuxArm64)
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.jetbrains.compose.experimental.macos.enabled=true
 compose.desktop.packaging.checkJdkVendor=false
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
-olcbox.version=1.0.2
+olcbox.version=1.0.4
 
 #Android
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.jetbrains.compose.experimental.macos.enabled=true
 compose.desktop.packaging.checkJdkVendor=false
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
-olcbox.version=1.0.1
+olcbox.version=1.0.2
 
 #Android
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.jetbrains.compose.experimental.macos.enabled=true
 compose.desktop.packaging.checkJdkVendor=false
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
-olcbox.version=1.0.5
+olcbox.version=1.0.6
 
 #Android
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.jetbrains.compose.experimental.macos.enabled=true
 compose.desktop.packaging.checkJdkVendor=false
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
-olcbox.version=1.0.0
+olcbox.version=1.0.1
 
 #Android
 android.useAndroidX=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ org.jetbrains.compose.experimental.macos.enabled=true
 compose.desktop.packaging.checkJdkVendor=false
 org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=false
-olcbox.version=1.0.4
+olcbox.version=1.0.5
 
 #Android
 android.useAndroidX=true

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -41,6 +41,8 @@ import org.olcbox.app.data.repository.LocationsRepository
 import org.olcbox.app.vpn.AndroidConnectionMode
 import org.olcbox.app.vpn.AndroidSocksProxySettings
 import org.olcbox.app.vpn.AndroidSplitTunnelMode
+import org.olcbox.app.vpn.RtcLogEvent
+import org.olcbox.app.vpn.RtcLogRecoveryClassifier
 import org.olcbox.app.vpn.UpstreamCandidate
 import org.olcbox.app.vpn.UpstreamNetworkSelector
 import org.olcbox.app.vpn.UpstreamTransport
@@ -137,6 +139,13 @@ class OlcboxVpnService : VpnService() {
             if (network == currentNetwork) {
                 updateUnderlyingNetwork(null)
                 unbindProcessFromNetwork()
+            }
+            if (OlcboxVpnState.status.value is VpnStatus.Connected ||
+                OlcboxVpnState.status.value is VpnStatus.Reconnecting
+            ) {
+                setStatus(VpnStatus.Reconnecting)
+                updateNotification("Waiting for network...")
+                scheduleTransportRetry(generation, "network lost", NETWORK_RETRY_DELAY_MS)
             }
             scope.launch {
                 delay(NETWORK_LOSS_FALLBACK_DELAY_MS)
@@ -540,6 +549,11 @@ class OlcboxVpnService : VpnService() {
         Mobile.setTransport(config.transport)
         Mobile.setDNS("1.1.1.1:53")
         Mobile.setVP8Options(config.vp8Fps.toLong(), config.vp8Batch.toLong())
+        Mobile.setLivenessOptions(
+            RTC_LIVENESS_INTERVAL_MS,
+            RTC_LIVENESS_TIMEOUT_MS,
+            RTC_LIVENESS_FAILURES
+        )
     }
 
     private fun startTun2socks(pfd: ParcelFileDescriptor): Boolean {
@@ -879,47 +893,16 @@ class OlcboxVpnService : VpnService() {
     }
 
     private fun handleRtcLine(line: String) {
-        val lowerLine = line.lowercase()
-
-        if (lowerLine.contains("ice connection state changed: connected") ||
-            lowerLine.contains("peer connection state changed: connected") ||
-            lowerLine.contains("socks5 server listening")
-        ) {
-            markRtcConnected()
-            return
-        }
-
-        if (lowerLine.contains("ice connection state changed: failed") ||
-            lowerLine.contains("peer connection state changed: failed")
-        ) {
-            noteRtcFailure(
-                reason = "RTC failed",
-                fullRestart = shouldRecreateTunnelOnRtcLoss(),
-                threshold = RTC_FAILED_RECOVERY_THRESHOLD
-            )
-            return
-        }
-
-        if (lowerLine.contains("ice connection state changed: closed") ||
-            lowerLine.contains("peer connection state changed: closed")
-        ) {
-            noteRtcFailure(
-                reason = "RTC closed",
-                fullRestart = shouldRecreateTunnelOnRtcLoss(),
-                threshold = RTC_CLOSED_RECOVERY_THRESHOLD
-            )
-            return
-        }
-
-        if (lowerLine.contains("network is unreachable") ||
-            lowerLine.contains("use of closed network connection") ||
-            lowerLine.contains("read/write on closed pipe")
-        ) {
-            noteRtcFailure(
-                reason = "RTC network path is closed",
-                fullRestart = false,
-                threshold = RTC_IO_ERROR_RECOVERY_THRESHOLD
-            )
+        when (val event = RtcLogRecoveryClassifier.classify(line)) {
+            RtcLogEvent.Connected -> markRtcConnected()
+            is RtcLogEvent.Failure -> {
+                noteRtcFailure(
+                    reason = event.reason,
+                    fullRestart = event.recreateTunnel && shouldRecreateTunnelOnRtcLoss(),
+                    threshold = event.threshold
+                )
+            }
+            null -> Unit
         }
     }
 
@@ -940,7 +923,12 @@ class OlcboxVpnService : VpnService() {
         fullRestart: Boolean,
         threshold: Int
     ) {
-        if (OlcboxVpnState.status.value !is VpnStatus.Connected) return
+        val status = OlcboxVpnState.status.value
+        if (status is VpnStatus.Reconnecting) {
+            scheduleTransportRetry(generation, reason, RECONNECT_RETRY_DELAY_MS)
+            return
+        }
+        if (status !is VpnStatus.Connected) return
 
         val now = System.currentTimeMillis()
         if (now - lastRtcConnectedAtMs < RTC_RECOVERY_GRACE_MS) return
@@ -1394,6 +1382,9 @@ class OlcboxVpnService : VpnService() {
         private const val LOCAL_SOCKS_PORT_BASE = 10818
         private const val LOCAL_SOCKS_PORT_MAX = 10858
         private const val MOBILE_READY_TIMEOUT_MS = 25_000L
+        private const val RTC_LIVENESS_INTERVAL_MS = 30_000L
+        private const val RTC_LIVENESS_TIMEOUT_MS = 15_000L
+        private const val RTC_LIVENESS_FAILURES = 6L
         private const val PREVIOUS_STOP_WAIT_MS = 2_000L
         private const val TUNNEL_HANDOFF_DELAY_MS = 300L
         private const val NETWORK_LOSS_FALLBACK_DELAY_MS = 300L
@@ -1402,9 +1393,6 @@ class OlcboxVpnService : VpnService() {
         private const val WATCHDOG_STALLED_SAMPLE_LIMIT = 3
         private const val RTC_RECOVERY_GRACE_MS = 2_500L
         private const val RTC_FAILURE_WINDOW_MS = 6_000L
-        private const val RTC_FAILED_RECOVERY_THRESHOLD = 1
-        private const val RTC_CLOSED_RECOVERY_THRESHOLD = 2
-        private const val RTC_IO_ERROR_RECOVERY_THRESHOLD = 3
         private const val RECONNECT_RETRY_DELAY_MS = 4_000L
         private const val NETWORK_RETRY_DELAY_MS = 8_000L
         private const val SOCKS_RELEASE_TIMEOUT_MS = 2_500L

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
@@ -54,6 +54,7 @@ data class LocationConfig(
 
     companion object {
         const val PROVIDER_JAZZ = "jazz"
+        const val PROVIDER_JITSI = "jitsi"
         const val PROVIDER_TELEMOST = "telemost"
         const val PROVIDER_WB_STREAM = "wbstream"
         const val DEFAULT_BYPASS_PROVIDER = PROVIDER_WB_STREAM
@@ -70,6 +71,7 @@ data class LocationConfig(
 
         val supportedBypassProviders = listOf(
             PROVIDER_JAZZ,
+            PROVIDER_JITSI,
             PROVIDER_TELEMOST,
             PROVIDER_WB_STREAM
         )
@@ -82,6 +84,7 @@ data class LocationConfig(
 
         fun supportedTransportsForProvider(provider: String): List<String> {
             return when (normalizeProvider(provider)) {
+                PROVIDER_JITSI -> listOf(TRANSPORT_DATACHANNEL)
                 PROVIDER_TELEMOST -> listOf(TRANSPORT_VP8CHANNEL, TRANSPORT_SEICHANNEL)
                 else -> supportedTransports
             }
@@ -90,9 +93,17 @@ data class LocationConfig(
         fun normalizeProvider(value: String): String {
             return when (value.trim().lowercase()) {
                 PROVIDER_JAZZ, "sberjazz", "sber_jazz" -> PROVIDER_JAZZ
+                PROVIDER_JITSI, "jitsi-meet", "meet.jit.si", "meet_cryptopro" -> PROVIDER_JITSI
                 PROVIDER_TELEMOST, "yandex", "yandex_telemost" -> PROVIDER_TELEMOST
                 PROVIDER_WB_STREAM, "wbstream", "wb-stream", "wildberries" -> PROVIDER_WB_STREAM
                 else -> DEFAULT_BYPASS_PROVIDER
+            }
+        }
+
+        fun defaultTransportForProvider(provider: String): String {
+            return when (normalizeProvider(provider)) {
+                PROVIDER_JITSI -> TRANSPORT_DATACHANNEL
+                else -> DEFAULT_TRANSPORT
             }
         }
 
@@ -101,15 +112,16 @@ data class LocationConfig(
                 TRANSPORT_DATACHANNEL, "data", "dc" -> TRANSPORT_DATACHANNEL
                 TRANSPORT_VP8CHANNEL, "vp8", "video_vp8", "video-vp8" -> TRANSPORT_VP8CHANNEL
                 TRANSPORT_SEICHANNEL, "sei", "sei_channel", "sei-channel", "h264_sei" -> TRANSPORT_SEICHANNEL
-                else -> DEFAULT_TRANSPORT
+                else -> defaultTransportForProvider(provider)
             }
             return normalized.takeIf { it in supportedTransportsForProvider(provider) }
-                ?: DEFAULT_TRANSPORT
+                ?: defaultTransportForProvider(provider)
         }
 
         fun providerDisplayName(provider: String): String {
             return when (normalizeProvider(provider)) {
                 PROVIDER_JAZZ -> "Jazz"
+                PROVIDER_JITSI -> "Jitsi"
                 PROVIDER_TELEMOST -> "Telemost"
                 PROVIDER_WB_STREAM -> "WB Stream"
                 else -> "WB Stream"

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/LocationSettingsScreen.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/LocationSettingsScreen.kt
@@ -526,6 +526,7 @@ private fun ActionsBar(
 private fun roomIdPlaceholder(provider: String): String {
     return when (LocationConfig.normalizeProvider(provider)) {
         LocationConfig.PROVIDER_TELEMOST -> "12345678901234"
+        LocationConfig.PROVIDER_JITSI -> "https://meet.cryptopro.ru/room-name"
         LocationConfig.PROVIDER_JAZZ -> "room id or any"
         LocationConfig.PROVIDER_WB_STREAM -> "123e4567-e89b-12d3-a456-426614174000"
         else -> "room id"

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifier.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifier.kt
@@ -31,6 +31,28 @@ internal object RtcLogRecoveryClassifier {
             )
         }
 
+        if (lowerLine.contains("conference end") ||
+            lowerLine.contains("conference ended") ||
+            lowerLine.contains("jitsi bridge closed")
+        ) {
+            return RtcLogEvent.Failure(
+                reason = "RTC conference ended",
+                recreateTunnel = true,
+                threshold = 1
+            )
+        }
+
+        if (lowerLine.contains("read welcome") ||
+            lowerLine.contains("unexpected handshake message") ||
+            lowerLine.contains("control_ping")
+        ) {
+            return RtcLogEvent.Failure(
+                reason = "RTC handshake failed",
+                recreateTunnel = false,
+                threshold = 1
+            )
+        }
+
         if (lowerLine.contains("control stream unhealthy")) {
             return RtcLogEvent.Failure(
                 reason = "RTC control stream unhealthy",
@@ -79,7 +101,9 @@ internal object RtcLogRecoveryClassifier {
 
         if (lowerLine.contains("network is unreachable") ||
             lowerLine.contains("use of closed network connection") ||
-            lowerLine.contains("read/write on closed pipe")
+            lowerLine.contains("read/write on closed pipe") ||
+            lowerLine.contains("remote not ready") ||
+            lowerLine.contains("read_err=eof")
         ) {
             return RtcLogEvent.Failure(
                 reason = "RTC network path is closed",

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifier.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifier.kt
@@ -1,0 +1,93 @@
+package org.olcbox.app.vpn
+
+internal sealed interface RtcLogEvent {
+    data object Connected : RtcLogEvent
+
+    data class Failure(
+        val reason: String,
+        val recreateTunnel: Boolean,
+        val threshold: Int
+    ) : RtcLogEvent
+}
+
+internal object RtcLogRecoveryClassifier {
+    fun classify(line: String): RtcLogEvent? {
+        val lowerLine = line.lowercase()
+
+        if (lowerLine.contains("ice connection state changed: connected") ||
+            lowerLine.contains("peer connection state changed: connected") ||
+            lowerLine.contains("socks5 server listening") ||
+            lowerLine.contains("link connected") ||
+            lowerLine.contains("session opened")
+        ) {
+            return RtcLogEvent.Connected
+        }
+
+        if (lowerLine.contains("session closed")) {
+            return RtcLogEvent.Failure(
+                reason = "RTC session closed",
+                recreateTunnel = true,
+                threshold = 1
+            )
+        }
+
+        if (lowerLine.contains("control stream unhealthy")) {
+            return RtcLogEvent.Failure(
+                reason = "RTC control stream unhealthy",
+                recreateTunnel = false,
+                threshold = 1
+            )
+        }
+
+        if (lowerLine.contains("server reconnect")) {
+            return RtcLogEvent.Failure(
+                reason = "RTC server requested reconnect",
+                recreateTunnel = false,
+                threshold = 1
+            )
+        }
+
+        if (lowerLine.contains("control missed pong") ||
+            lowerLine.contains("missed_pongs")
+        ) {
+            return RtcLogEvent.Failure(
+                reason = "RTC liveness missed pong",
+                recreateTunnel = false,
+                threshold = 2
+            )
+        }
+
+        if (lowerLine.contains("ice connection state changed: failed") ||
+            lowerLine.contains("peer connection state changed: failed")
+        ) {
+            return RtcLogEvent.Failure(
+                reason = "RTC failed",
+                recreateTunnel = true,
+                threshold = 1
+            )
+        }
+
+        if (lowerLine.contains("ice connection state changed: closed") ||
+            lowerLine.contains("peer connection state changed: closed")
+        ) {
+            return RtcLogEvent.Failure(
+                reason = "RTC closed",
+                recreateTunnel = true,
+                threshold = 2
+            )
+        }
+
+        if (lowerLine.contains("network is unreachable") ||
+            lowerLine.contains("use of closed network connection") ||
+            lowerLine.contains("read/write on closed pipe")
+        ) {
+            return RtcLogEvent.Failure(
+                reason = "RTC network path is closed",
+                recreateTunnel = false,
+                threshold = 3
+            )
+        }
+
+        return null
+    }
+}

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
@@ -173,6 +173,23 @@ class LocationsRepositoryImplTest {
     }
 
     @Test
+    fun importsJitsiDatachannelOlcRtcUri() = runTest {
+        val source = FakeLocationsDataSource()
+        val room = "https://meet.cryptopro.ru/olcrtc-razares-jitsi-20260516"
+        val input = "olcrtc://jitsi?datachannel@$room#${"c".repeat(64)}${'$'}razares-jitsi"
+
+        LocationsRepositoryImpl(source).importText(input)
+
+        val imported = source.stored
+        assertNotNull(imported)
+        val location = imported.locations.single().location
+        assertEquals(LocationConfig.PROVIDER_JITSI, location.bypassProvider)
+        assertEquals(LocationConfig.TRANSPORT_DATACHANNEL, location.transport)
+        assertEquals(room, location.id)
+        assertEquals("razares-jitsi", location.name)
+    }
+
+    @Test
     fun importsOlcRtcSubscriptionAndAppliesLocalNames() = runTest {
         val source = FakeLocationsDataSource()
         val input = """
@@ -385,6 +402,10 @@ class LocationsRepositoryImplTest {
 
     @Test
     fun exposesAllWorkingCarrierTransportPairs() {
+        assertEquals(
+            listOf(LocationConfig.TRANSPORT_DATACHANNEL),
+            LocationConfig.supportedTransportsForProvider(LocationConfig.PROVIDER_JITSI)
+        )
         assertEquals(
             listOf(
                 LocationConfig.TRANSPORT_VP8CHANNEL,

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifierTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifierTest.kt
@@ -53,6 +53,42 @@ class RtcLogRecoveryClassifierTest {
     }
 
     @Test
+    fun treatsConferenceEndAsImmediateTunnelRecovery() {
+        assertEquals(
+            RtcLogEvent.Failure(
+                reason = "RTC conference ended",
+                recreateTunnel = true,
+                threshold = 1
+            ),
+            RtcLogRecoveryClassifier.classify("Client link reported conference end: jitsi bridge closed")
+        )
+    }
+
+    @Test
+    fun treatsHandshakeTimeoutAsRecoverableTransportFailure() {
+        assertEquals(
+            RtcLogEvent.Failure(
+                reason = "RTC handshake failed",
+                recreateTunnel = false,
+                threshold = 1
+            ),
+            RtcLogRecoveryClassifier.classify("handshake client: read welcome: read hdr: timeout")
+        )
+    }
+
+    @Test
+    fun treatsUnexpectedControlPingAsRecoverableTransportFailure() {
+        assertEquals(
+            RtcLogEvent.Failure(
+                reason = "RTC handshake failed",
+                recreateTunnel = false,
+                threshold = 1
+            ),
+            RtcLogRecoveryClassifier.classify("unexpected handshake message: got \"CONTROL_PING\"")
+        )
+    }
+
+    @Test
     fun ignoresTrafficLines() {
         assertNull(
             RtcLogRecoveryClassifier.classify(

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifierTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/vpn/RtcLogRecoveryClassifierTest.kt
@@ -1,0 +1,63 @@
+package org.olcbox.app.vpn
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RtcLogRecoveryClassifierTest {
+
+    @Test
+    fun marksLinkConnectedAsHealthy() {
+        assertEquals(
+            RtcLogEvent.Connected,
+            RtcLogRecoveryClassifier.classify("Link connected")
+        )
+    }
+
+    @Test
+    fun treatsSessionClosedAsImmediateTunnelRecovery() {
+        assertEquals(
+            RtcLogEvent.Failure(
+                reason = "RTC session closed",
+                recreateTunnel = true,
+                threshold = 1
+            ),
+            RtcLogRecoveryClassifier.classify(
+                "session closed: id=444b68b7-4504-4644-a93e-88c12210d537 reason=closed"
+            )
+        )
+    }
+
+    @Test
+    fun treatsControlMissedPongAsLivenessFailure() {
+        assertEquals(
+            RtcLogEvent.Failure(
+                reason = "RTC liveness missed pong",
+                recreateTunnel = false,
+                threshold = 2
+            ),
+            RtcLogRecoveryClassifier.classify("control missed pong on server: missed_pongs=1")
+        )
+    }
+
+    @Test
+    fun treatsControlUnhealthyAsImmediateRecovery() {
+        assertEquals(
+            RtcLogEvent.Failure(
+                reason = "RTC control stream unhealthy",
+                recreateTunnel = false,
+                threshold = 1
+            ),
+            RtcLogRecoveryClassifier.classify("control stream unhealthy on server: missed_pongs=3")
+        )
+    }
+
+    @Test
+    fun ignoresTrafficLines() {
+        assertNull(
+            RtcLogRecoveryClassifier.classify(
+                "traffic: session=abc addr=example.com:443 in=100 out=200"
+            )
+        )
+    }
+}

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopRtcRecoveryState.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopRtcRecoveryState.kt
@@ -1,0 +1,58 @@
+package org.olcbox.app.vpn
+
+internal data class DesktopRecoveryRequest(
+    val reason: String,
+    val fullRestart: Boolean
+)
+
+internal class DesktopRtcRecoveryState(
+    private val startupGraceMs: Long,
+    private val failureWindowMs: Long,
+    private val trafficProbeThreshold: Int
+) {
+    private var lastConnectedAtMs: Long = 0L
+    private var lastRtcFailureAtMs: Long = 0L
+    private var rtcFailureCount: Int = 0
+    private var trafficProbeFailures: Int = 0
+
+    fun markConnected(nowMs: Long = System.currentTimeMillis()) {
+        lastConnectedAtMs = nowMs
+        lastRtcFailureAtMs = 0L
+        rtcFailureCount = 0
+        trafficProbeFailures = 0
+    }
+
+    fun noteRtcFailure(
+        failure: RtcLogEvent.Failure,
+        nowMs: Long = System.currentTimeMillis()
+    ): DesktopRecoveryRequest? {
+        if (nowMs - lastConnectedAtMs < startupGraceMs) return null
+
+        rtcFailureCount = if (nowMs - lastRtcFailureAtMs <= failureWindowMs) {
+            rtcFailureCount + 1
+        } else {
+            1
+        }
+        lastRtcFailureAtMs = nowMs
+
+        return if (rtcFailureCount >= failure.threshold) {
+            DesktopRecoveryRequest(failure.reason, failure.recreateTunnel)
+        } else {
+            null
+        }
+    }
+
+    fun noteTrafficProbe(success: Boolean): DesktopRecoveryRequest? {
+        if (success) {
+            trafficProbeFailures = 0
+            return null
+        }
+
+        trafficProbeFailures += 1
+        return if (trafficProbeFailures >= trafficProbeThreshold) {
+            DesktopRecoveryRequest("Desktop traffic probe failed", fullRestart = false)
+        } else {
+            null
+        }
+    }
+}

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -23,6 +23,7 @@ import org.olcbox.app.desktop.DesktopOs
 import org.olcbox.app.desktop.DesktopPaths
 import org.olcbox.app.vpn.desktop.DesktopNativeAssets
 import org.olcbox.app.vpn.desktop.DesktopProxyController
+import org.olcbox.app.vpn.desktop.HttpConnectProxy
 import org.olcbox.app.vpn.desktop.LinuxPrivilege
 import org.olcbox.app.vpn.desktop.LinuxTunController
 import org.olcbox.app.vpn.desktop.OlcRtcCommand
@@ -38,13 +39,15 @@ import java.util.concurrent.TimeUnit
 class DesktopVpnManager private constructor(
     private val locationsRepository: LocationsRepository,
     private val proxyController: DesktopProxyController = DesktopProxyController.current(),
-    private val pacServer: PacServer = PacServer()
+    private val pacServer: PacServer = PacServer(),
+    private val httpConnectProxy: HttpConnectProxy = HttpConnectProxy()
 ) : VpnManager {
 
     constructor(locationsRepository: LocationsRepository) : this(
         locationsRepository = locationsRepository,
         proxyController = DesktopProxyController.current(),
-        pacServer = PacServer()
+        pacServer = PacServer(),
+        httpConnectProxy = HttpConnectProxy()
     )
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -129,12 +132,14 @@ class DesktopVpnManager private constructor(
         ).normalized()
         _socksProxySettings.value = settings
         pacServer.updateSocksTarget(settings.host, settings.port)
+        httpConnectProxy.updateSocksTarget(settings.host, settings.port)
     }
 
     fun updateSocksProxySettings(settings: DesktopSocksProxySettings) {
         val normalized = settings.normalized()
         _socksProxySettings.value = normalized
         pacServer.updateSocksTarget(normalized.host, normalized.port)
+        httpConnectProxy.updateSocksTarget(normalized.host, normalized.port)
     }
 
     fun close() {
@@ -198,10 +203,15 @@ class DesktopVpnManager private constructor(
                 startTunLogReader(tunProcess ?: error("hev-socks5-tunnel process is missing"))
             } else {
                 pacServer.start(socksSettings.host, socksSettings.port)
+                if (DesktopPaths.os == DesktopOs.Windows) {
+                    httpConnectProxy.start(socksSettings.host, socksSettings.port)
+                }
                 proxyController.enable(
                     pacUrl = pacServer.url,
                     socksHost = socksSettings.host,
-                    socksPort = socksSettings.port
+                    socksPort = socksSettings.port,
+                    httpProxyHost = HttpConnectProxy.HTTP_PROXY_HOST,
+                    httpProxyPort = httpConnectProxy.boundPort
                 )
 
                 if (requestGeneration != generation) {
@@ -238,6 +248,7 @@ class DesktopVpnManager private constructor(
             }
 
             pacServer.stop()
+            httpConnectProxy.stop()
             stopProcess(process)
             process = null
 
@@ -313,6 +324,7 @@ class DesktopVpnManager private constructor(
         }
 
         pacServer.stop()
+        httpConnectProxy.stop()
 
         watchdogJob?.cancel()
         watchdogJob = null

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -27,8 +27,11 @@ import org.olcbox.app.vpn.desktop.LinuxPrivilege
 import org.olcbox.app.vpn.desktop.LinuxTunController
 import org.olcbox.app.vpn.desktop.OlcRtcCommand
 import org.olcbox.app.vpn.desktop.PacServer
+import java.net.HttpURLConnection
 import java.net.InetSocketAddress
+import java.net.Proxy
 import java.net.Socket
+import java.net.URL
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
@@ -62,9 +65,16 @@ class DesktopVpnManager private constructor(
     private var operationJob: Job? = null
     private var logJob: Job? = null
     private var tunLogJob: Job? = null
+    private var watchdogJob: Job? = null
     private var process: Process? = null
     private var tunProcess: Process? = null
     private var generation = 0L
+    private var recoveryRequestedForGeneration = 0L
+    private val recoveryState = DesktopRtcRecoveryState(
+        startupGraceMs = RTC_RECOVERY_GRACE_MS,
+        failureWindowMs = RTC_FAILURE_WINDOW_MS,
+        trafficProbeThreshold = TRAFFIC_PROBE_FAILURE_THRESHOLD
+    )
     private val linuxTunController = LinuxTunController(::addLog)
 
     override fun needsPermission(): Boolean = false
@@ -161,7 +171,8 @@ class DesktopVpnManager private constructor(
                 socksSettings = socksSettings,
                 ready = ready,
                 logOutput = true,
-                privileged = useLinuxTun
+                privileged = useLinuxTun,
+                requestGeneration = requestGeneration
             )
 
             waitForOlcRtcReady(
@@ -194,7 +205,10 @@ class DesktopVpnManager private constructor(
                 }
             }
 
+            recoveryRequestedForGeneration = 0L
+            recoveryState.markConnected()
             setStatus(VpnStatus.Connected)
+            startWatchdog(requestGeneration, socksSettings.port)
             addLog(if (useLinuxTun) "Desktop Linux TUN connected" else "Desktop proxy connected")
         } catch (e: Exception) {
             if (e is CancellationException) {
@@ -224,7 +238,15 @@ class DesktopVpnManager private constructor(
             process = null
 
             if (e !is CancellationException && requestGeneration == generation) {
-                setStatus(VpnStatus.Error(e.message ?: "Desktop start failed"))
+                if (isRestart) {
+                    setStatus(VpnStatus.Reconnecting)
+                    scheduleDesktopRetry(
+                        requestGeneration = requestGeneration,
+                        reason = e.message ?: "desktop start failed"
+                    )
+                } else {
+                    setStatus(VpnStatus.Error(e.message ?: "Desktop start failed"))
+                }
             }
         }
     }
@@ -234,7 +256,8 @@ class DesktopVpnManager private constructor(
         socksSettings: DesktopSocksProxySettings,
         ready: CompletableDeferred<Unit>,
         logOutput: Boolean,
-        privileged: Boolean
+        privileged: Boolean,
+        requestGeneration: Long
     ): Process {
         val binaries = DesktopNativeAssets.resolveOlcRtcBinaryCandidates()
         var lastException: Exception? = null
@@ -247,7 +270,8 @@ class DesktopVpnManager private constructor(
                     socksSettings = socksSettings,
                     ready = ready,
                     logOutput = logOutput,
-                    privileged = privileged
+                    privileged = privileged,
+                    requestGeneration = requestGeneration
                 )
             } catch (e: Exception) {
                 lastException = e
@@ -286,6 +310,9 @@ class DesktopVpnManager private constructor(
 
         pacServer.stop()
 
+        watchdogJob?.cancel()
+        watchdogJob = null
+
         stopProcess(process)
         process = null
 
@@ -307,11 +334,13 @@ class DesktopVpnManager private constructor(
         socksSettings: DesktopSocksProxySettings,
         ready: CompletableDeferred<Unit>,
         logOutput: Boolean,
-        privileged: Boolean
+        privileged: Boolean,
+        requestGeneration: Long
     ): Process {
         val config = location.normalized()
         val provider = OlcRtcCommand.desktopProviderArg(config.bypassProvider)
         val dataDir = DesktopNativeAssets.resolveOlcRtcDataDir()
+        val configFile = DesktopPaths.appDataDir().resolve("olcrtc-client.yaml")
         val command = OlcRtcCommand(
             binary = binary,
             location = config,
@@ -319,8 +348,11 @@ class DesktopVpnManager private constructor(
             socksPort = socksSettings.port,
             socksUser = socksSettings.username,
             socksPass = socksSettings.password,
-            dataDir = dataDir
-        ).args()
+            dataDir = dataDir,
+            configFile = configFile
+        )
+        command.writeConfigFile()
+        val args = command.args()
 
         addLog("Starting olcRTC carrier=$provider, transport=${config.transport}, room=${config.id}, port=${socksSettings.port}")
 
@@ -329,7 +361,7 @@ class DesktopVpnManager private constructor(
         }
 
         val processBuilder = ProcessBuilder(
-            if (privileged) LinuxPrivilege.command(command) else command
+            if (privileged) LinuxPrivilege.command(args) else args
         ).redirectErrorStream(true)
 
         processBuilder.environment()["NO_PROXY"] = "127.0.0.1,localhost"
@@ -345,6 +377,8 @@ class DesktopVpnManager private constructor(
                     if (logOutput) {
                         addLog("rtc: $line")
                     }
+
+                    handleRtcLine(line, requestGeneration = requestGeneration)
 
                     if (line.contains("SOCKS5 server listening", ignoreCase = true)) {
                         ready.complete(Unit)
@@ -372,6 +406,123 @@ class DesktopVpnManager private constructor(
                     addLog("tun: $line")
                 }
             }
+        }
+    }
+
+    private fun startWatchdog(requestGeneration: Long, socksPort: Int) {
+        watchdogJob?.cancel()
+        watchdogJob = scope.launch {
+            while (isActive && requestGeneration == generation && _status.value is VpnStatus.Connected) {
+                delay(WATCHDOG_INTERVAL_MS)
+
+                if (requestGeneration != generation || _status.value !is VpnStatus.Connected) return@launch
+
+                if (process?.isAlive != true) {
+                    requestDesktopRecovery(
+                        reason = "olcRTC process stopped",
+                        fullRestart = false,
+                        requestGeneration = requestGeneration
+                    )
+                    return@launch
+                }
+
+                if (!canConnectToSocks(socksPort)) {
+                    requestDesktopRecovery(
+                        reason = "SOCKS port unavailable",
+                        fullRestart = true,
+                        requestGeneration = requestGeneration
+                    )
+                    return@launch
+                }
+
+                recoveryState.noteTrafficProbe(success = httpProbeThroughSocks(socksPort))?.let { request ->
+                    requestDesktopRecovery(
+                        reason = request.reason,
+                        fullRestart = request.fullRestart,
+                        requestGeneration = requestGeneration
+                    )
+                    return@launch
+                }
+            }
+        }
+    }
+
+    private fun handleRtcLine(line: String, requestGeneration: Long) {
+        when (val event = RtcLogRecoveryClassifier.classify(line)) {
+            RtcLogEvent.Connected -> recoveryState.markConnected()
+            is RtcLogEvent.Failure -> {
+                recoveryState.noteRtcFailure(event)?.let { request ->
+                    requestDesktopRecovery(
+                        reason = request.reason,
+                        fullRestart = request.fullRestart,
+                        requestGeneration = requestGeneration
+                    )
+                }
+            }
+            null -> Unit
+        }
+    }
+
+    private fun requestDesktopRecovery(
+        reason: String,
+        fullRestart: Boolean,
+        requestGeneration: Long
+    ) {
+        if (requestGeneration != generation) return
+        if (_status.value !is VpnStatus.Connected && _status.value !is VpnStatus.Reconnecting) return
+        if (recoveryRequestedForGeneration == requestGeneration) return
+
+        recoveryRequestedForGeneration = requestGeneration
+        addLog("Watchdog: $reason; reconnecting${if (fullRestart) " with full restart" else ""}")
+
+        scope.launch {
+            mutex.withLock {
+                if (requestGeneration != generation) return@withLock
+                setStatus(VpnStatus.Reconnecting)
+                stopDesktopMode(finalStatus = false)
+                if (requestGeneration == generation) {
+                    startDesktopMode(requestGeneration, isRestart = true)
+                }
+            }
+        }
+    }
+
+    private fun scheduleDesktopRetry(requestGeneration: Long, reason: String) {
+        scope.launch {
+            delay(RECONNECT_RETRY_DELAY_MS)
+            if (requestGeneration != generation) return@launch
+            if (_status.value !is VpnStatus.Reconnecting) return@launch
+
+            addLog("Retrying desktop transport after $reason")
+
+            mutex.withLock {
+                if (requestGeneration != generation) return@withLock
+                if (_status.value !is VpnStatus.Reconnecting) return@withLock
+
+                startDesktopMode(requestGeneration, isRestart = true)
+            }
+        }
+    }
+
+    private fun httpProbeThroughSocks(socksPort: Int): Boolean {
+        return HTTP_PROBE_URLS.any { url ->
+            runCatching {
+                val proxy = Proxy(
+                    Proxy.Type.SOCKS,
+                    InetSocketAddress(PacServer.LOCAL_SOCKS_HOST, socksPort)
+                )
+                val connection = URL(url).openConnection(proxy) as HttpURLConnection
+
+                try {
+                    connection.instanceFollowRedirects = false
+                    connection.connectTimeout = HTTP_PROBE_TIMEOUT_MS.toInt()
+                    connection.readTimeout = HTTP_PROBE_TIMEOUT_MS.toInt()
+                    connection.requestMethod = "GET"
+                    connection.responseCode in 200..399
+                } finally {
+                    connection.disconnect()
+                }
+            }.isSuccess
         }
     }
 
@@ -452,5 +603,15 @@ class DesktopVpnManager private constructor(
         const val PROCESS_STOP_TIMEOUT_MS = 3_000L
         const val PROCESS_KILL_TIMEOUT_MS = 1_000L
         const val DEFAULT_LOCATION_PING_PARALLELISM = 4
+        const val WATCHDOG_INTERVAL_MS = 30_000L
+        const val HTTP_PROBE_TIMEOUT_MS = 8_000L
+        const val RECONNECT_RETRY_DELAY_MS = 3_000L
+        const val RTC_RECOVERY_GRACE_MS = 2_500L
+        const val RTC_FAILURE_WINDOW_MS = 6_000L
+        const val TRAFFIC_PROBE_FAILURE_THRESHOLD = 2
+        val HTTP_PROBE_URLS = listOf(
+            "https://www.google.com/generate_204",
+            "https://cloudflare.com/cdn-cgi/trace"
+        )
     }
 }

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -198,7 +198,11 @@ class DesktopVpnManager private constructor(
                 startTunLogReader(tunProcess ?: error("hev-socks5-tunnel process is missing"))
             } else {
                 pacServer.start(socksSettings.host, socksSettings.port)
-                proxyController.enable(pacServer.url)
+                proxyController.enable(
+                    pacUrl = pacServer.url,
+                    socksHost = socksSettings.host,
+                    socksPort = socksSettings.port
+                )
 
                 if (requestGeneration != generation) {
                     throw CancellationException("Desktop start superseded")

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/OlcRtcConnectionChecker.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/OlcRtcConnectionChecker.kt
@@ -236,17 +236,21 @@ internal object OlcRtcConnectionChecker {
     ): Process {
         val normalized = config.normalized()
         val dataDir = DesktopNativeAssets.resolveOlcRtcDataDir()
+        val configFile = dataDir.parent.resolve("olcrtc-check-$socksPort.yaml")
 
         val command = OlcRtcCommand(
             binary = binary,
             location = normalized,
             socksHost = PacServer.LOCAL_SOCKS_HOST,
             socksPort = socksPort,
-            dataDir = dataDir
-        ).args()
+            dataDir = dataDir,
+            configFile = configFile
+        )
+        command.writeConfigFile()
+        val args = command.args()
 
         val processBuilder = ProcessBuilder(
-            if (privileged) LinuxPrivilege.command(command) else command
+            if (privileged) LinuxPrivilege.command(args) else args
         ).redirectErrorStream(true)
 
         processBuilder.environment()["NO_PROXY"] = "127.0.0.1,localhost"

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopNativeAssets.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopNativeAssets.kt
@@ -96,6 +96,11 @@ internal object DesktopNativeAssets {
             return target
         }
 
+        if (target.exists()) {
+            makeExecutable(target)
+            return target
+        }
+
         error("Bundled native binary is missing: $resourceName")
     }
 

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -118,7 +118,8 @@ internal class WindowsProxyController : DesktopProxyController {
 
     override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
         backup = readState()
-        enableCommands(socksHost, socksPort).forEach { runCommand(it) }
+        enableCommands(socksHost, socksPort, removeAutoConfigUrl = backup?.autoConfigUrl != null)
+            .forEach { runCommand(it) }
         refreshProxySettings()
     }
 
@@ -161,13 +162,25 @@ internal class WindowsProxyController : DesktopProxyController {
     companion object {
         private const val REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
 
-        fun enableCommands(socksHost: String, socksPort: Int): List<List<String>> {
-            return listOf(
-                setDwordCommand("ProxyEnable", "1"),
-                setStringCommand("ProxyServer", "socks=$socksHost:$socksPort"),
-                setStringCommand("ProxyOverride", "<local>;localhost;127.*"),
-                listOf("reg", "delete", REGISTRY_KEY, "/v", "AutoConfigURL", "/f")
-            )
+        fun enableCommands(
+            socksHost: String,
+            socksPort: Int,
+            removeAutoConfigUrl: Boolean = true
+        ): List<List<String>> {
+            return buildList {
+                add(
+                    setDwordCommand("ProxyEnable", "1")
+                )
+                add(
+                    setStringCommand("ProxyServer", "socks=$socksHost:$socksPort")
+                )
+                add(
+                    setStringCommand("ProxyOverride", "<local>;localhost;127.*")
+                )
+                if (removeAutoConfigUrl) {
+                    add(listOf("reg", "delete", REGISTRY_KEY, "/v", "AutoConfigURL", "/f"))
+                }
+            }
         }
 
         fun restoreCommands(state: WindowsProxyState): List<List<String>> {

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -227,7 +227,7 @@ internal class WindowsProxyController : DesktopProxyController {
                 add(
                     setStringCommand(
                         "ProxyServer",
-                        "http=$httpProxyHost:$httpProxyPort;https=$httpProxyHost:$httpProxyPort;socks=$socksHost:$socksPort"
+                        "$httpProxyHost:$httpProxyPort"
                     )
                 )
                 add(
@@ -297,7 +297,7 @@ internal class WindowsProxyController : DesktopProxyController {
                 "winhttp",
                 "set",
                 "proxy",
-                "proxy-server=http=$host:$port;https=$host:$port",
+                "proxy-server=$host:$port",
                 "bypass-list=<local>;localhost;127.*"
             )
         }

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -6,7 +6,11 @@ import org.olcbox.app.desktop.DesktopOs
 import org.olcbox.app.desktop.DesktopPaths
 
 internal interface DesktopProxyController {
-    suspend fun enable(pacUrl: String)
+    suspend fun enable(
+        pacUrl: String,
+        socksHost: String = PacServer.LOCAL_SOCKS_HOST,
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT
+    )
     suspend fun restore()
 
     companion object {
@@ -22,7 +26,7 @@ internal interface DesktopProxyController {
 }
 
 internal class UnsupportedProxyController : DesktopProxyController {
-    override suspend fun enable(pacUrl: String) {
+    override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
         error("System proxy mode supports macOS and Windows")
     }
 
@@ -38,7 +42,7 @@ internal data class MacOsAutoProxyState(
 internal class MacOsProxyController : DesktopProxyController {
     private var backup: List<MacOsAutoProxyState>? = null
 
-    override suspend fun enable(pacUrl: String) {
+    override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
         val services = enabledNetworkServices()
         backup = services.map { service ->
             readAutoProxyState(service)
@@ -112,9 +116,9 @@ internal data class WindowsProxyState(
 internal class WindowsProxyController : DesktopProxyController {
     private var backup: WindowsProxyState? = null
 
-    override suspend fun enable(pacUrl: String) {
+    override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
         backup = readState()
-        enableCommands(pacUrl).forEach { runCommand(it) }
+        enableCommands(socksHost, socksPort).forEach { runCommand(it) }
         refreshProxySettings()
     }
 
@@ -157,10 +161,12 @@ internal class WindowsProxyController : DesktopProxyController {
     companion object {
         private const val REGISTRY_KEY = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Internet Settings"
 
-        fun enableCommands(pacUrl: String): List<List<String>> {
+        fun enableCommands(socksHost: String, socksPort: Int): List<List<String>> {
             return listOf(
-                setDwordCommand("ProxyEnable", "0"),
-                setStringCommand("AutoConfigURL", pacUrl)
+                setDwordCommand("ProxyEnable", "1"),
+                setStringCommand("ProxyServer", "socks=$socksHost:$socksPort"),
+                setStringCommand("ProxyOverride", "<local>;localhost;127.*"),
+                listOf("reg", "delete", REGISTRY_KEY, "/v", "AutoConfigURL", "/f")
             )
         }
 

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -124,8 +124,18 @@ internal data class WindowsProxyState(
     val proxyEnable: String?,
     val proxyServer: String?,
     val proxyOverride: String?,
-    val autoConfigUrl: String?
+    val autoConfigUrl: String?,
+    val winHttp: WindowsWinHttpProxyState = WindowsWinHttpProxyState.Unknown
 )
+
+internal sealed interface WindowsWinHttpProxyState {
+    data object Direct : WindowsWinHttpProxyState
+    data class Proxy(
+        val proxyServer: String,
+        val bypassList: String?
+    ) : WindowsWinHttpProxyState
+    data object Unknown : WindowsWinHttpProxyState
+}
 
 internal class WindowsProxyController : DesktopProxyController {
     private var backup: WindowsProxyState? = null
@@ -145,7 +155,13 @@ internal class WindowsProxyController : DesktopProxyController {
             httpProxyPort = httpProxyPort,
             removeAutoConfigUrl = backup?.autoConfigUrl != null
         )
-            .forEach { runCommand(it) }
+            .forEach { command ->
+                if (command.isWinHttpCommand()) {
+                    runCatching { runCommand(command) }
+                } else {
+                    runCommand(command)
+                }
+            }
         refreshProxySettings()
     }
 
@@ -163,7 +179,8 @@ internal class WindowsProxyController : DesktopProxyController {
             proxyEnable = queryValue("ProxyEnable"),
             proxyServer = queryValue("ProxyServer"),
             proxyOverride = queryValue("ProxyOverride"),
-            autoConfigUrl = queryValue("AutoConfigURL")
+            autoConfigUrl = queryValue("AutoConfigURL"),
+            winHttp = readWinHttpState()
         )
     }
 
@@ -179,6 +196,14 @@ internal class WindowsProxyController : DesktopProxyController {
             ?.lastOrNull()
             ?.trim()
             ?.takeIf { it.isNotBlank() }
+    }
+
+    private suspend fun readWinHttpState(): WindowsWinHttpProxyState {
+        val output = runCatching {
+            runCommand(listOf("netsh", "winhttp", "dump"))
+        }.getOrNull() ?: return WindowsWinHttpProxyState.Unknown
+
+        return parseWinHttpDump(output)
     }
 
     private suspend fun refreshProxySettings() {
@@ -211,15 +236,40 @@ internal class WindowsProxyController : DesktopProxyController {
                 if (removeAutoConfigUrl) {
                     add(listOf("reg", "delete", REGISTRY_KEY, "/v", "AutoConfigURL", "/f"))
                 }
+                add(winHttpSetProxyCommand(httpProxyHost, httpProxyPort))
             }
         }
 
         fun restoreCommands(state: WindowsProxyState): List<List<String>> {
-            return listOf(
+            return listOfNotNull(
                 valueCommand("ProxyEnable", state.proxyEnable, isDword = true),
                 valueCommand("ProxyServer", state.proxyServer, isDword = false),
                 valueCommand("ProxyOverride", state.proxyOverride, isDword = false),
-                valueCommand("AutoConfigURL", state.autoConfigUrl, isDword = false)
+                valueCommand("AutoConfigURL", state.autoConfigUrl, isDword = false),
+                winHttpRestoreCommand(state.winHttp)
+            )
+        }
+
+        fun parseWinHttpDump(output: String): WindowsWinHttpProxyState {
+            val setProxyLine = output.lineSequence()
+                .map { it.trim() }
+                .firstOrNull { it.startsWith("set proxy", ignoreCase = true) }
+
+            if (setProxyLine == null) {
+                return if (output.contains("reset proxy", ignoreCase = true)) {
+                    WindowsWinHttpProxyState.Direct
+                } else {
+                    WindowsWinHttpProxyState.Unknown
+                }
+            }
+
+            val proxyServer = extractNetshValue(setProxyLine, "proxy-server")
+                ?: return WindowsWinHttpProxyState.Unknown
+            val bypassList = extractNetshValue(setProxyLine, "bypass-list")
+
+            return WindowsWinHttpProxyState.Proxy(
+                proxyServer = proxyServer,
+                bypassList = bypassList
             )
         }
 
@@ -241,6 +291,41 @@ internal class WindowsProxyController : DesktopProxyController {
             return listOf("reg", "add", REGISTRY_KEY, "/v", name, "/t", "REG_DWORD", "/d", value, "/f")
         }
 
+        private fun winHttpSetProxyCommand(host: String, port: Int): List<String> {
+            return listOf(
+                "netsh",
+                "winhttp",
+                "set",
+                "proxy",
+                "proxy-server=http=$host:$port;https=$host:$port",
+                "bypass-list=<local>;localhost;127.*"
+            )
+        }
+
+        private fun winHttpRestoreCommand(state: WindowsWinHttpProxyState): List<String>? {
+            return when (state) {
+                WindowsWinHttpProxyState.Direct -> listOf("netsh", "winhttp", "reset", "proxy")
+                is WindowsWinHttpProxyState.Proxy -> buildList {
+                    add("netsh")
+                    add("winhttp")
+                    add("set")
+                    add("proxy")
+                    add("proxy-server=${state.proxyServer}")
+                    state.bypassList?.takeIf { it.isNotBlank() }?.let {
+                        add("bypass-list=$it")
+                    }
+                }
+                WindowsWinHttpProxyState.Unknown -> null
+            }
+        }
+
+        private fun extractNetshValue(line: String, key: String): String? {
+            val match = Regex("""\b$key=(?:"([^"]*)"|(\S+))""", RegexOption.IGNORE_CASE).find(line)
+                ?: return null
+            return match.groupValues.getOrNull(1)?.takeIf { it.isNotBlank() }
+                ?: match.groupValues.getOrNull(2)?.takeIf { it.isNotBlank() }
+        }
+
         fun refreshCommand(): List<String> {
             val script = """
                 ${'$'}signature = '[System.Runtime.InteropServices.DllImport("wininet.dll", SetLastError = true)] public static extern bool InternetSetOption(System.IntPtr hInternet, int dwOption, System.IntPtr lpBuffer, int dwBufferLength);';
@@ -251,6 +336,10 @@ internal class WindowsProxyController : DesktopProxyController {
             return listOf("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script)
         }
     }
+}
+
+private fun List<String>.isWinHttpCommand(): Boolean {
+    return size >= 2 && this[0].equals("netsh", ignoreCase = true) && this[1].equals("winhttp", ignoreCase = true)
 }
 
 private suspend fun runCommand(command: List<String>): String = withContext(Dispatchers.IO) {

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -9,7 +9,9 @@ internal interface DesktopProxyController {
     suspend fun enable(
         pacUrl: String,
         socksHost: String = PacServer.LOCAL_SOCKS_HOST,
-        socksPort: Int = PacServer.LOCAL_SOCKS_PORT
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
+        httpProxyHost: String = HttpConnectProxy.HTTP_PROXY_HOST,
+        httpProxyPort: Int = HttpConnectProxy.HTTP_PROXY_PORT
     )
     suspend fun restore()
 
@@ -26,7 +28,13 @@ internal interface DesktopProxyController {
 }
 
 internal class UnsupportedProxyController : DesktopProxyController {
-    override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
+    override suspend fun enable(
+        pacUrl: String,
+        socksHost: String,
+        socksPort: Int,
+        httpProxyHost: String,
+        httpProxyPort: Int
+    ) {
         error("System proxy mode supports macOS and Windows")
     }
 
@@ -42,7 +50,13 @@ internal data class MacOsAutoProxyState(
 internal class MacOsProxyController : DesktopProxyController {
     private var backup: List<MacOsAutoProxyState>? = null
 
-    override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
+    override suspend fun enable(
+        pacUrl: String,
+        socksHost: String,
+        socksPort: Int,
+        httpProxyHost: String,
+        httpProxyPort: Int
+    ) {
         val services = enabledNetworkServices()
         backup = services.map { service ->
             readAutoProxyState(service)
@@ -116,9 +130,21 @@ internal data class WindowsProxyState(
 internal class WindowsProxyController : DesktopProxyController {
     private var backup: WindowsProxyState? = null
 
-    override suspend fun enable(pacUrl: String, socksHost: String, socksPort: Int) {
+    override suspend fun enable(
+        pacUrl: String,
+        socksHost: String,
+        socksPort: Int,
+        httpProxyHost: String,
+        httpProxyPort: Int
+    ) {
         backup = readState()
-        enableCommands(socksHost, socksPort, removeAutoConfigUrl = backup?.autoConfigUrl != null)
+        enableCommands(
+            socksHost = socksHost,
+            socksPort = socksPort,
+            httpProxyHost = httpProxyHost,
+            httpProxyPort = httpProxyPort,
+            removeAutoConfigUrl = backup?.autoConfigUrl != null
+        )
             .forEach { runCommand(it) }
         refreshProxySettings()
     }
@@ -165,6 +191,8 @@ internal class WindowsProxyController : DesktopProxyController {
         fun enableCommands(
             socksHost: String,
             socksPort: Int,
+            httpProxyHost: String = HttpConnectProxy.HTTP_PROXY_HOST,
+            httpProxyPort: Int = HttpConnectProxy.HTTP_PROXY_PORT,
             removeAutoConfigUrl: Boolean = true
         ): List<List<String>> {
             return buildList {
@@ -172,7 +200,10 @@ internal class WindowsProxyController : DesktopProxyController {
                     setDwordCommand("ProxyEnable", "1")
                 )
                 add(
-                    setStringCommand("ProxyServer", "socks=$socksHost:$socksPort")
+                    setStringCommand(
+                        "ProxyServer",
+                        "http=$httpProxyHost:$httpProxyPort;https=$httpProxyHost:$httpProxyPort;socks=$socksHost:$socksPort"
+                    )
                 )
                 add(
                     setStringCommand("ProxyOverride", "<local>;localhost;127.*")

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/HttpConnectProxy.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/HttpConnectProxy.kt
@@ -1,0 +1,243 @@
+package org.olcbox.app.vpn.desktop
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URI
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class HttpConnectProxy(
+    private val host: String = HTTP_PROXY_HOST,
+    private val port: Int = HTTP_PROXY_PORT,
+    private val connector: Connector = Connector { targetHost, targetPort, socksTarget ->
+        Socket(Proxy(Proxy.Type.SOCKS, InetSocketAddress(socksTarget.host, socksTarget.port))).apply {
+            connect(InetSocketAddress.createUnresolved(targetHost, targetPort), CONNECT_TIMEOUT_MS)
+        }
+    }
+) : AutoCloseable {
+    private val lock = Any()
+    @Volatile
+    private var socksTarget = SocksTarget(PacServer.LOCAL_SOCKS_HOST, PacServer.LOCAL_SOCKS_PORT)
+    private var serverSocket: ServerSocket? = null
+    private var executor: ExecutorService = newExecutor()
+
+    val boundPort: Int
+        get() = serverSocket?.localPort ?: port
+
+    fun start(
+        socksHost: String = PacServer.LOCAL_SOCKS_HOST,
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT
+    ) {
+        updateSocksTarget(socksHost, socksPort)
+        synchronized(lock) {
+            if (serverSocket != null) return
+            executor = newExecutor()
+            serverSocket = ServerSocket().apply {
+                reuseAddress = true
+                bind(InetSocketAddress(host, port))
+            }
+            executor.execute(::acceptLoop)
+        }
+    }
+
+    fun updateSocksTarget(
+        socksHost: String = PacServer.LOCAL_SOCKS_HOST,
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT
+    ) {
+        socksTarget = SocksTarget(
+            host = socksHost.ifBlank { PacServer.LOCAL_SOCKS_HOST },
+            port = socksPort
+        )
+    }
+
+    fun stop() {
+        synchronized(lock) {
+            runCatching { serverSocket?.close() }
+            serverSocket = null
+            executor.shutdownNow()
+            executor.awaitTermination(1, TimeUnit.SECONDS)
+        }
+    }
+
+    override fun close() = stop()
+
+    private fun acceptLoop() {
+        while (!Thread.currentThread().isInterrupted) {
+            val client = runCatching { serverSocket?.accept() }.getOrNull() ?: return
+            executor.execute { handleClient(client) }
+        }
+    }
+
+    private fun handleClient(client: Socket) {
+        client.use { clientSocket ->
+            clientSocket.soTimeout = READ_TIMEOUT_MS
+            val input = clientSocket.getInputStream()
+            val output = clientSocket.getOutputStream()
+            val requestLine = input.readHttpLine() ?: return
+            val headers = input.readHeaders()
+            val parts = requestLine.split(" ", limit = 3)
+            if (parts.size != 3) {
+                output.writeResponse(400, "Bad Request")
+                return
+            }
+
+            if (parts[0].equals("CONNECT", ignoreCase = true)) {
+                handleConnect(parts[1], clientSocket, output)
+            } else {
+                handleHttpRequest(parts[0], parts[1], parts[2], headers, clientSocket, output)
+            }
+        }
+    }
+
+    private fun handleConnect(authority: String, client: Socket, clientOutput: OutputStream) {
+        val target = parseAuthority(authority) ?: run {
+            clientOutput.writeResponse(400, "Bad CONNECT target")
+            return
+        }
+        connector.connect(target.host, target.port, socksTarget).use { upstream ->
+            client.soTimeout = 0
+            upstream.soTimeout = 0
+            clientOutput.write("HTTP/1.1 200 Connection Established\r\n\r\n".toByteArray(Charsets.ISO_8859_1))
+            clientOutput.flush()
+            pumpBothWays(client, upstream)
+        }
+    }
+
+    private fun handleHttpRequest(
+        method: String,
+        target: String,
+        version: String,
+        headers: List<String>,
+        client: Socket,
+        clientOutput: OutputStream
+    ) {
+        val request = parseHttpTarget(target, headers) ?: run {
+            clientOutput.writeResponse(400, "Bad HTTP target")
+            return
+        }
+        connector.connect(request.host, request.port, socksTarget).use { upstream ->
+            client.soTimeout = 0
+            upstream.soTimeout = 0
+            val upstreamOutput = upstream.getOutputStream()
+            upstreamOutput.write("$method ${request.path} $version\r\n".toByteArray(Charsets.ISO_8859_1))
+            headers
+                .filterNot { it.startsWith("Proxy-Connection:", ignoreCase = true) }
+                .forEach { upstreamOutput.write("$it\r\n".toByteArray(Charsets.ISO_8859_1)) }
+            upstreamOutput.write("\r\n".toByteArray(Charsets.ISO_8859_1))
+            upstreamOutput.flush()
+            pumpBothWays(client, upstream)
+        }
+    }
+
+    private fun pumpBothWays(left: Socket, right: Socket) {
+        val done = CountDownLatch(1)
+        val a = executor.submit { left.getInputStream().copyToAndShutdown(right, done) }
+        val b = executor.submit { right.getInputStream().copyToAndShutdown(left, done) }
+
+        runCatching { done.await() }
+        runCatching { left.close() }
+        runCatching { right.close() }
+        runCatching { a.get(1, TimeUnit.SECONDS) }
+        runCatching { b.get(1, TimeUnit.SECONDS) }
+    }
+
+    private fun InputStream.copyToAndShutdown(target: Socket, done: CountDownLatch) {
+        try {
+            runCatching {
+                copyTo(target.getOutputStream())
+                target.shutdownOutput()
+            }
+        } finally {
+            done.countDown()
+        }
+    }
+
+    data class SocksTarget(
+        val host: String,
+        val port: Int
+    )
+
+    fun interface Connector {
+        fun connect(host: String, port: Int, socksTarget: SocksTarget): Socket
+    }
+
+    companion object {
+        const val HTTP_PROXY_HOST = "127.0.0.1"
+        const val HTTP_PROXY_PORT = 10810
+        private const val CONNECT_TIMEOUT_MS = 10_000
+        private const val READ_TIMEOUT_MS = 30_000
+
+        private fun newExecutor(): ExecutorService {
+            return Executors.newCachedThreadPool { runnable ->
+                Thread(runnable, "OlcboxHttpConnectProxy").apply { isDaemon = true }
+            }
+        }
+
+        private fun InputStream.readHeaders(): List<String> {
+            val headers = mutableListOf<String>()
+            while (true) {
+                val line = readHttpLine() ?: break
+                if (line.isEmpty()) break
+                headers.add(line)
+            }
+            return headers
+        }
+
+        private fun InputStream.readHttpLine(): String? {
+            val out = ByteArrayOutputStream()
+            while (out.size() < 8192) {
+                val value = read()
+                if (value < 0) return if (out.size() == 0) null else out.toString(Charsets.ISO_8859_1)
+                if (value == '\n'.code) break
+                if (value != '\r'.code) out.write(value)
+            }
+            return out.toString(Charsets.ISO_8859_1)
+        }
+
+        private fun OutputStream.writeResponse(status: Int, message: String) {
+            write("HTTP/1.1 $status $message\r\nConnection: close\r\nContent-Length: 0\r\n\r\n".toByteArray(Charsets.ISO_8859_1))
+            flush()
+        }
+
+        private fun parseAuthority(value: String): Target? {
+            val host = value.substringBeforeLast(":", missingDelimiterValue = "")
+            val port = value.substringAfterLast(":", missingDelimiterValue = "").toIntOrNull()
+            if (host.isBlank() || port == null || port !in 1..65535) return null
+            return Target(host, port, "")
+        }
+
+        private fun parseHttpTarget(target: String, headers: List<String>): Target? {
+            return if (target.startsWith("http://", ignoreCase = true)) {
+                val uri = URI(target)
+                Target(
+                    host = uri.host ?: return null,
+                    port = uri.port.takeIf { it > 0 } ?: 80,
+                    path = buildString {
+                        append(uri.rawPath.takeIf { !it.isNullOrBlank() } ?: "/")
+                        if (!uri.rawQuery.isNullOrBlank()) append("?").append(uri.rawQuery)
+                    }
+                )
+            } else {
+                val hostHeader = headers.firstOrNull { it.startsWith("Host:", ignoreCase = true) }
+                    ?.substringAfter(":")
+                    ?.trim()
+                    ?: return null
+                val authority = parseAuthority(hostHeader) ?: Target(hostHeader, 80, "")
+                authority.copy(path = target.ifBlank { "/" })
+            }
+        }
+    }
+
+    private data class Target(
+        val host: String,
+        val port: Int,
+        val path: String
+    )
+}

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/OlcRtcCommand.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/OlcRtcCommand.kt
@@ -1,7 +1,9 @@
 package org.olcbox.app.vpn.desktop
 
 import org.olcbox.app.data.model.LocationConfig
+import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.Path
 
 internal data class OlcRtcCommand(
     val binary: Path,
@@ -10,52 +12,74 @@ internal data class OlcRtcCommand(
     val socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
     val socksUser: String = "",
     val socksPass: String = "",
-    val dataDir: Path? = null
+    val dataDir: Path? = null,
+    val configFile: Path = Path("olcrtc-client.yaml")
 ) {
     fun args(): List<String> {
-        val config = location.normalized()
-        val provider = desktopProviderArg(config.bypassProvider)
-        val baseArgs = listOf(
-            binary.toString(),
-            "-mode", "cnc",
-            "-link", "direct",
-            "-transport", config.transport,
-            "-carrier", provider,
-            "-id", config.id,
-            "-client-id", config.clientId,
-            "-key", config.key,
-            "-socks-host", socksHost,
-            "-socks-port", socksPort.toString(),
-            "-dns", "1.1.1.1:53"
-        ) + socksAuthArgs()
-        val transportArgs = when (config.transport) {
-            LocationConfig.TRANSPORT_VP8CHANNEL -> listOf(
-                "-vp8-fps", config.vp8Fps.toString(),
-                "-vp8-batch", config.vp8Batch.toString()
-            )
-            LocationConfig.TRANSPORT_SEICHANNEL -> listOf(
-                "-fps", "60",
-                "-batch", "64",
-                "-frag", "900",
-                "-ack-ms", "2000"
-            )
-            else -> emptyList()
-        }
-        return baseArgs + transportArgs + listOfNotNull(
-            dataDir?.let { "-data" },
-            dataDir?.toString()
-        )
+        return listOf(binary.toString(), configFile.toString())
     }
 
-    private fun socksAuthArgs(): List<String> {
-        return if (socksUser.isBlank()) {
-            emptyList()
-        } else {
-            listOf("-socks-user", socksUser, "-socks-pass", socksPass)
+    fun writeConfigFile() {
+        configFile.parent?.let { Files.createDirectories(it) }
+        Files.writeString(configFile, configYaml())
+    }
+
+    fun configYaml(): String {
+        val config = location.normalized()
+        val provider = desktopProviderArg(config.bypassProvider)
+        val dataPath = dataDir ?: configFile.parent ?: Path(".")
+        val builder = StringBuilder()
+
+        builder.appendLine("mode: cnc")
+        builder.appendLine("link: direct")
+        builder.appendLine("auth:")
+        builder.appendLine("  provider: $provider")
+        builder.appendLine("room:")
+        builder.appendLine("  id: ${yamlScalar(config.id)}")
+        builder.appendLine("crypto:")
+        builder.appendLine("  key: ${yamlScalar(config.key)}")
+        builder.appendLine("net:")
+        builder.appendLine("  transport: ${config.transport}")
+        builder.appendLine("  dns: '1.1.1.1:53'")
+        builder.appendLine("socks:")
+        builder.appendLine("  host: ${yamlScalar(socksHost)}")
+        builder.appendLine("  port: $socksPort")
+        builder.appendLine("  user: ${yamlScalar(socksUser)}")
+        builder.appendLine("  pass: ${yamlScalar(socksPass)}")
+        builder.appendLine("liveness:")
+        builder.appendLine("  interval: ${DESKTOP_LIVENESS_INTERVAL_SECONDS}s")
+        builder.appendLine("  timeout: ${DESKTOP_LIVENESS_TIMEOUT_SECONDS}s")
+        builder.appendLine("  failures: $DESKTOP_LIVENESS_FAILURES")
+
+        when (config.transport) {
+            LocationConfig.TRANSPORT_VP8CHANNEL -> {
+                builder.appendLine("vp8:")
+                builder.appendLine("  fps: ${config.vp8Fps}")
+                builder.appendLine("  batch_size: ${config.vp8Batch}")
+            }
+            LocationConfig.TRANSPORT_SEICHANNEL -> {
+                builder.appendLine("sei:")
+                builder.appendLine("  fps: 60")
+                builder.appendLine("  batch_size: 64")
+                builder.appendLine("  fragment_size: 900")
+                builder.appendLine("  ack_timeout_ms: 2000")
+            }
         }
+
+        builder.appendLine("data: ${yamlScalar(dataPath.toString())}")
+        builder.appendLine("debug: false")
+        return builder.toString()
+    }
+
+    private fun yamlScalar(value: String): String {
+        return "'${value.replace("'", "''")}'"
     }
 
     companion object {
+        const val DESKTOP_LIVENESS_INTERVAL_SECONDS = 30
+        const val DESKTOP_LIVENESS_TIMEOUT_SECONDS = 15
+        const val DESKTOP_LIVENESS_FAILURES = 6
+
         fun desktopProviderArg(provider: String): String {
             val normalizedProvider = LocationConfig.normalizeProvider(provider)
             return when (normalizedProvider) {

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/DesktopRtcRecoveryStateTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/DesktopRtcRecoveryStateTest.kt
@@ -1,0 +1,108 @@
+package org.olcbox.app.vpn
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DesktopRtcRecoveryStateTest {
+
+    @Test
+    fun ignoresRtcFailuresDuringStartupGrace() {
+        val state = DesktopRtcRecoveryState(
+            startupGraceMs = 2_500,
+            failureWindowMs = 6_000,
+            trafficProbeThreshold = 2
+        )
+
+        state.markConnected(nowMs = 10_000)
+
+        assertNull(
+            state.noteRtcFailure(
+                RtcLogEvent.Failure("RTC closed", recreateTunnel = true, threshold = 1),
+                nowMs = 11_000
+            )
+        )
+    }
+
+    @Test
+    fun requestsRecoveryWhenRtcFailureThresholdIsReached() {
+        val state = DesktopRtcRecoveryState(
+            startupGraceMs = 0,
+            failureWindowMs = 6_000,
+            trafficProbeThreshold = 2
+        )
+
+        state.markConnected(nowMs = 10_000)
+
+        assertNull(
+            state.noteRtcFailure(
+                RtcLogEvent.Failure("RTC liveness missed pong", recreateTunnel = false, threshold = 2),
+                nowMs = 13_000
+            )
+        )
+
+        assertEquals(
+            DesktopRecoveryRequest("RTC liveness missed pong", fullRestart = false),
+            state.noteRtcFailure(
+                RtcLogEvent.Failure("RTC liveness missed pong", recreateTunnel = false, threshold = 2),
+                nowMs = 14_000
+            )
+        )
+    }
+
+    @Test
+    fun trafficProbeRequestsRecoveryAfterConsecutiveFailures() {
+        val state = DesktopRtcRecoveryState(
+            startupGraceMs = 0,
+            failureWindowMs = 6_000,
+            trafficProbeThreshold = 2
+        )
+
+        state.markConnected(nowMs = 10_000)
+
+        assertNull(state.noteTrafficProbe(success = false))
+        assertEquals(
+            DesktopRecoveryRequest("Desktop traffic probe failed", fullRestart = false),
+            state.noteTrafficProbe(success = false)
+        )
+    }
+
+    @Test
+    fun trafficProbeSuccessClearsFailureCount() {
+        val state = DesktopRtcRecoveryState(
+            startupGraceMs = 0,
+            failureWindowMs = 6_000,
+            trafficProbeThreshold = 2
+        )
+
+        state.markConnected(nowMs = 10_000)
+
+        assertNull(state.noteTrafficProbe(success = false))
+        assertNull(state.noteTrafficProbe(success = true))
+        assertNull(state.noteTrafficProbe(success = false))
+    }
+
+    @Test
+    fun markConnectedAllowsNewRecoveryAfterPreviousRequest() {
+        val state = DesktopRtcRecoveryState(
+            startupGraceMs = 0,
+            failureWindowMs = 6_000,
+            trafficProbeThreshold = 2
+        )
+
+        state.markConnected(nowMs = 10_000)
+
+        assertEquals(
+            DesktopRecoveryRequest("Desktop traffic probe failed", fullRestart = false),
+            state.noteTrafficProbe(success = false) ?: state.noteTrafficProbe(success = false)
+        )
+
+        state.markConnected(nowMs = 20_000)
+
+        assertNull(state.noteTrafficProbe(success = false))
+        assertEquals(
+            DesktopRecoveryRequest("Desktop traffic probe failed", fullRestart = false),
+            state.noteTrafficProbe(success = false)
+        )
+    }
+}

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -253,12 +253,12 @@ class DesktopProxyModeTest {
     }
 
     @Test
-    fun windowsProxyCommandsUseHttpAndSocksSystemProxy() {
+    fun windowsProxyCommandsUseSingleHttpSystemProxy() {
         val enable = WindowsProxyController.enableCommands("127.0.0.1", 10808)
         assertEquals("reg", enable.first().first())
         assertContains(enable.flatten(), "ProxyEnable")
         assertContains(enable.flatten(), "ProxyServer")
-        assertContains(enable.flatten(), "http=127.0.0.1:10810;https=127.0.0.1:10810;socks=127.0.0.1:10808")
+        assertContains(enable.flatten(), "127.0.0.1:10810")
         assertContains(enable.flatten(), "AutoConfigURL")
         assertContains(enable.flatten(), "delete")
     }
@@ -311,7 +311,7 @@ class DesktopProxyModeTest {
                     "winhttp",
                     "set",
                     "proxy",
-                    "proxy-server=http=127.0.0.1:10810;https=127.0.0.1:10810",
+                    "proxy-server=127.0.0.1:10810",
                     "bypass-list=<local>;localhost;127.*"
                 )
             }

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -283,7 +283,8 @@ class DesktopProxyModeTest {
                 proxyEnable = "0x1",
                 proxyServer = "127.0.0.1:8888",
                 proxyOverride = "<local>",
-                autoConfigUrl = null
+                autoConfigUrl = null,
+                winHttp = WindowsWinHttpProxyState.Direct
             )
         )
 
@@ -292,6 +293,107 @@ class DesktopProxyModeTest {
         assertContains(restore.flatten(), "ProxyOverride")
         assertContains(restore.flatten(), "AutoConfigURL")
         assertContains(restore.flatten(), "delete")
+    }
+
+    @Test
+    fun windowsProxyCommandsSetWinHttpToOlcboxHttpProxy() {
+        val enable = WindowsProxyController.enableCommands(
+            socksHost = "127.0.0.1",
+            socksPort = 10808,
+            httpProxyHost = "127.0.0.1",
+            httpProxyPort = 10810
+        )
+
+        assertTrue(
+            enable.any { command ->
+                command == listOf(
+                    "netsh",
+                    "winhttp",
+                    "set",
+                    "proxy",
+                    "proxy-server=http=127.0.0.1:10810;https=127.0.0.1:10810",
+                    "bypass-list=<local>;localhost;127.*"
+                )
+            }
+        )
+    }
+
+    @Test
+    fun windowsProxyCommandsRestoreDirectWinHttpProxy() {
+        val restore = WindowsProxyController.restoreCommands(
+            WindowsProxyState(
+                proxyEnable = "0x1",
+                proxyServer = null,
+                proxyOverride = null,
+                autoConfigUrl = null,
+                winHttp = WindowsWinHttpProxyState.Direct
+            )
+        )
+
+        assertTrue(restore.any { command -> command == listOf("netsh", "winhttp", "reset", "proxy") })
+    }
+
+    @Test
+    fun windowsProxyCommandsRestorePreviousWinHttpProxy() {
+        val restore = WindowsProxyController.restoreCommands(
+            WindowsProxyState(
+                proxyEnable = "0x1",
+                proxyServer = null,
+                proxyOverride = null,
+                autoConfigUrl = null,
+                winHttp = WindowsWinHttpProxyState.Proxy(
+                    proxyServer = "http=127.0.0.1:3067;https=127.0.0.1:3067",
+                    bypassList = "<local>"
+                )
+            )
+        )
+
+        assertTrue(
+            restore.any { command ->
+                command == listOf(
+                    "netsh",
+                    "winhttp",
+                    "set",
+                    "proxy",
+                    "proxy-server=http=127.0.0.1:3067;https=127.0.0.1:3067",
+                    "bypass-list=<local>"
+                )
+            }
+        )
+    }
+
+    @Test
+    fun windowsWinHttpDumpParserKeepsDirectState() {
+        val state = WindowsProxyController.parseWinHttpDump(
+            """
+            # WinHTTP Proxy Configuration
+            pushd winhttp
+            reset proxy
+            popd
+            """.trimIndent()
+        )
+
+        assertEquals(WindowsWinHttpProxyState.Direct, state)
+    }
+
+    @Test
+    fun windowsWinHttpDumpParserKeepsProxyState() {
+        val state = WindowsProxyController.parseWinHttpDump(
+            """
+            # WinHTTP Proxy Configuration
+            pushd winhttp
+            set proxy proxy-server="http=127.0.0.1:3067;https=127.0.0.1:3067" bypass-list="<local>"
+            popd
+            """.trimIndent()
+        )
+
+        assertEquals(
+            WindowsWinHttpProxyState.Proxy(
+                proxyServer = "http=127.0.0.1:3067;https=127.0.0.1:3067",
+                bypassList = "<local>"
+            ),
+            state
+        )
     }
 
     @Test

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -37,31 +37,99 @@ class DesktopProxyModeTest {
     fun olcRtcCommandUsesLocationProviderRoomAndKey() {
         LocationConfig.supportedBypassProviders.forEach { provider ->
             val binary = Path.of("/tmp/olcrtc")
+            val configFile = Path.of("/tmp/olcbox-client.yaml")
             val command = OlcRtcCommand(
                 binary = binary,
                 location = LocationConfig("Test", "room-$provider", "b".repeat(64), provider),
                 socksHost = "127.0.0.1",
-                socksPort = 10808
+                socksPort = 10808,
+                configFile = configFile
             ).args()
 
-            assertEquals(binary.toString(), command[0])
-            assertEquals(listOf("-mode", "cnc"), command.slice(1..2))
-            assertContains(command, "-transport")
+            assertEquals(listOf(binary.toString(), configFile.toString()), command)
+        }
+    }
+
+    @Test
+    fun olcRtcCommandWritesUniversalCarrierYamlConfig() {
+        val dataDir = Path.of("/tmp/olcbox-data")
+        val configFile = Path.of("/tmp/olcbox-client.yaml")
+        val command = OlcRtcCommand(
+            binary = Path.of("/tmp/olcrtc"),
+            location = LocationConfig(
+                name = "Jitsi",
+                id = "https://meet.cryptopro.ru/room-one",
+                key = "b".repeat(64),
+                bypassProvider = LocationConfig.PROVIDER_JITSI,
+                transport = LocationConfig.TRANSPORT_DATACHANNEL
+            ),
+            socksHost = "127.0.0.1",
+            socksPort = 10808,
+            socksUser = "user",
+            socksPass = "pass",
+            dataDir = dataDir,
+            configFile = configFile
+        )
+
+        val yaml = command.configYaml()
+
+        assertContains(yaml, "mode: cnc")
+        assertContains(yaml, "link: direct")
+        assertContains(yaml, "provider: jitsi")
+        assertContains(yaml, "id: 'https://meet.cryptopro.ru/room-one'")
+        assertContains(yaml, "key: '${"b".repeat(64)}'")
+        assertContains(yaml, "transport: datachannel")
+        assertContains(yaml, "dns: '1.1.1.1:53'")
+        assertContains(yaml, "host: '127.0.0.1'")
+        assertContains(yaml, "port: 10808")
+        assertContains(yaml, "user: 'user'")
+        assertContains(yaml, "pass: 'pass'")
+        assertContains(yaml, "interval: 30s")
+        assertContains(yaml, "timeout: 15s")
+        assertContains(yaml, "failures: 6")
+        assertContains(yaml, "data: '${dataDir}'")
+    }
+
+    @Test
+    fun olcRtcCommandDefaultsJitsiToDatachannelInYaml() {
+        val command = OlcRtcCommand(
+            binary = Path.of("/tmp/olcrtc"),
+            location = LocationConfig(
+                name = "Jitsi",
+                id = "https://meet.cryptopro.ru/room-one",
+                key = "b".repeat(64),
+                bypassProvider = LocationConfig.PROVIDER_JITSI,
+                transport = ""
+            ),
+            configFile = Path.of("/tmp/olcbox-client.yaml")
+        )
+
+        val yaml = command.configYaml()
+
+        assertContains(yaml, "provider: jitsi")
+        assertContains(yaml, "transport: datachannel")
+        assertTrue("vp8:" !in yaml)
+    }
+
+    @Test
+    fun olcRtcCommandAddsTransportSpecificYamlOnlyWhenNeeded() {
+        LocationConfig.supportedBypassProviders.forEach { provider ->
+            val command = OlcRtcCommand(
+                binary = Path.of("/tmp/olcrtc"),
+                location = LocationConfig("Test", "room-$provider", "b".repeat(64), provider),
+                configFile = Path.of("/tmp/olcbox-client.yaml")
+            )
+
+            val yaml = command.configYaml()
             val expectedTransport = LocationConfig.defaultTransportForProvider(provider)
-            assertContains(command, expectedTransport)
+            assertContains(yaml, "transport: $expectedTransport")
             if (expectedTransport == LocationConfig.TRANSPORT_VP8CHANNEL) {
-                assertContains(command, "-vp8-fps")
-                assertContains(command, "60")
-                assertContains(command, "-vp8-batch")
-                assertContains(command, "64")
+                assertContains(yaml, "vp8:")
+                assertContains(yaml, "fps: 60")
+                assertContains(yaml, "batch_size: 64")
             } else {
-                assertTrue("-vp8-fps" !in command)
-                assertTrue("-vp8-batch" !in command)
+                assertTrue("vp8:" !in yaml)
             }
-            assertEquals(OlcRtcCommand.desktopProviderArg(provider), command[command.indexOf("-carrier") + 1])
-            assertEquals(LocationConfig.DEFAULT_CLIENT_ID, command[command.indexOf("-client-id") + 1])
-            assertContains(command, "room-$provider")
-            assertContains(command, "10808")
         }
     }
 
@@ -77,12 +145,11 @@ class DesktopProxyModeTest {
                 bypassProvider = LocationConfig.PROVIDER_WB_STREAM,
                 transport = LocationConfig.TRANSPORT_DATACHANNEL
             ),
-            dataDir = dataDir
+            dataDir = dataDir,
+            configFile = Path.of("/tmp/olcbox-client.yaml")
         ).args()
 
-        assertContains(command, LocationConfig.TRANSPORT_DATACHANNEL)
-        assertTrue("-vp8-fps" !in command)
-        assertEquals(dataDir.toString(), command[command.indexOf("-data") + 1])
+        assertEquals(listOf(Path.of("/tmp/olcrtc").toString(), Path.of("/tmp/olcbox-client.yaml").toString()), command)
     }
 
     @Test
@@ -95,15 +162,19 @@ class DesktopProxyModeTest {
                 key = "c".repeat(64),
                 bypassProvider = LocationConfig.PROVIDER_TELEMOST,
                 transport = LocationConfig.TRANSPORT_SEICHANNEL
-            )
-        ).args()
+            ),
+            configFile = Path.of("/tmp/olcbox-client.yaml")
+        )
 
-        assertContains(command, LocationConfig.TRANSPORT_SEICHANNEL)
-        assertEquals("60", command[command.indexOf("-fps") + 1])
-        assertEquals("64", command[command.indexOf("-batch") + 1])
-        assertEquals("900", command[command.indexOf("-frag") + 1])
-        assertEquals("2000", command[command.indexOf("-ack-ms") + 1])
-        assertTrue("-vp8-fps" !in command)
+        val yaml = command.configYaml()
+
+        assertContains(yaml, "transport: seichannel")
+        assertContains(yaml, "sei:")
+        assertContains(yaml, "fps: 60")
+        assertContains(yaml, "batch_size: 64")
+        assertContains(yaml, "fragment_size: 900")
+        assertContains(yaml, "ack_timeout_ms: 2000")
+        assertTrue("vp8:" !in yaml)
     }
 
     @Test
@@ -145,10 +216,11 @@ class DesktopProxyModeTest {
                     id = "room-wb",
                     key = "b".repeat(64),
                     bypassProvider = provider
-                )
-            ).args()
+                ),
+                configFile = Path.of("/tmp/olcbox-client.yaml")
+            ).configYaml()
 
-            assertEquals("wbstream", command[command.indexOf("-carrier") + 1])
+            assertContains(command, "provider: wbstream")
         }
     }
 

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -252,12 +252,18 @@ class DesktopProxyModeTest {
     }
 
     @Test
-    fun windowsProxyCommandsBackupShapeIsRestorable() {
-        val enable = WindowsProxyController.enableCommands("http://127.0.0.1:10809/proxy.pac")
+    fun windowsProxyCommandsUseDirectSocksSystemProxy() {
+        val enable = WindowsProxyController.enableCommands("127.0.0.1", 10808)
         assertEquals("reg", enable.first().first())
+        assertContains(enable.flatten(), "ProxyEnable")
+        assertContains(enable.flatten(), "ProxyServer")
+        assertContains(enable.flatten(), "socks=127.0.0.1:10808")
         assertContains(enable.flatten(), "AutoConfigURL")
-        assertContains(enable.flatten(), "http://127.0.0.1:10809/proxy.pac")
+        assertContains(enable.flatten(), "delete")
+    }
 
+    @Test
+    fun windowsProxyCommandsBackupShapeIsRestorable() {
         val restore = WindowsProxyController.restoreCommands(
             WindowsProxyState(
                 proxyEnable = "0x1",

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -36,21 +36,28 @@ class DesktopProxyModeTest {
     @Test
     fun olcRtcCommandUsesLocationProviderRoomAndKey() {
         LocationConfig.supportedBypassProviders.forEach { provider ->
+            val binary = Path.of("/tmp/olcrtc")
             val command = OlcRtcCommand(
-                binary = Path.of("/tmp/olcrtc"),
+                binary = binary,
                 location = LocationConfig("Test", "room-$provider", "b".repeat(64), provider),
                 socksHost = "127.0.0.1",
                 socksPort = 10808
             ).args()
 
-            assertEquals("/tmp/olcrtc", command[0])
+            assertEquals(binary.toString(), command[0])
             assertEquals(listOf("-mode", "cnc"), command.slice(1..2))
             assertContains(command, "-transport")
-            assertContains(command, LocationConfig.TRANSPORT_VP8CHANNEL)
-            assertContains(command, "-vp8-fps")
-            assertContains(command, "60")
-            assertContains(command, "-vp8-batch")
-            assertContains(command, "64")
+            val expectedTransport = LocationConfig.defaultTransportForProvider(provider)
+            assertContains(command, expectedTransport)
+            if (expectedTransport == LocationConfig.TRANSPORT_VP8CHANNEL) {
+                assertContains(command, "-vp8-fps")
+                assertContains(command, "60")
+                assertContains(command, "-vp8-batch")
+                assertContains(command, "64")
+            } else {
+                assertTrue("-vp8-fps" !in command)
+                assertTrue("-vp8-batch" !in command)
+            }
             assertEquals(OlcRtcCommand.desktopProviderArg(provider), command[command.indexOf("-carrier") + 1])
             assertEquals(LocationConfig.DEFAULT_CLIENT_ID, command[command.indexOf("-client-id") + 1])
             assertContains(command, "room-$provider")
@@ -60,6 +67,7 @@ class DesktopProxyModeTest {
 
     @Test
     fun olcRtcCommandAllowsDatachannelForNonTelemostProviders() {
+        val dataDir = Path.of("/tmp/olcbox-data")
         val command = OlcRtcCommand(
             binary = Path.of("/tmp/olcrtc"),
             location = LocationConfig(
@@ -69,12 +77,12 @@ class DesktopProxyModeTest {
                 bypassProvider = LocationConfig.PROVIDER_WB_STREAM,
                 transport = LocationConfig.TRANSPORT_DATACHANNEL
             ),
-            dataDir = Path.of("/tmp/olcbox-data")
+            dataDir = dataDir
         ).args()
 
         assertContains(command, LocationConfig.TRANSPORT_DATACHANNEL)
         assertTrue("-vp8-fps" !in command)
-        assertEquals("/tmp/olcbox-data", command[command.indexOf("-data") + 1])
+        assertEquals(dataDir.toString(), command[command.indexOf("-data") + 1])
     }
 
     @Test

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DesktopProxyModeTest {
@@ -260,6 +261,19 @@ class DesktopProxyModeTest {
         assertContains(enable.flatten(), "socks=127.0.0.1:10808")
         assertContains(enable.flatten(), "AutoConfigURL")
         assertContains(enable.flatten(), "delete")
+    }
+
+    @Test
+    fun windowsProxyCommandsSkipPacDeleteWhenAutoConfigUrlIsAbsent() {
+        val enable = WindowsProxyController.enableCommands(
+            socksHost = "127.0.0.1",
+            socksPort = 10808,
+            removeAutoConfigUrl = false
+        )
+
+        assertContains(enable.flatten(), "ProxyEnable")
+        assertContains(enable.flatten(), "ProxyServer")
+        assertFalse(enable.any { command -> command.contains("AutoConfigURL") && command.contains("delete") })
     }
 
     @Test

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -253,12 +253,12 @@ class DesktopProxyModeTest {
     }
 
     @Test
-    fun windowsProxyCommandsUseDirectSocksSystemProxy() {
+    fun windowsProxyCommandsUseHttpAndSocksSystemProxy() {
         val enable = WindowsProxyController.enableCommands("127.0.0.1", 10808)
         assertEquals("reg", enable.first().first())
         assertContains(enable.flatten(), "ProxyEnable")
         assertContains(enable.flatten(), "ProxyServer")
-        assertContains(enable.flatten(), "socks=127.0.0.1:10808")
+        assertContains(enable.flatten(), "http=127.0.0.1:10810;https=127.0.0.1:10810;socks=127.0.0.1:10808")
         assertContains(enable.flatten(), "AutoConfigURL")
         assertContains(enable.flatten(), "delete")
     }

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/HttpConnectProxyTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/HttpConnectProxyTest.kt
@@ -1,0 +1,73 @@
+package org.olcbox.app.vpn.desktop
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HttpConnectProxyTest {
+    @Test
+    fun connectRequestTunnelsBytesToTarget() {
+        ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { target ->
+            val targetPort = target.localPort
+            val targetThread = thread(start = true, isDaemon = true) {
+                target.accept().use { socket ->
+                    val buffer = ByteArray(4)
+                    socket.getInputStream().readNBytes(buffer, 0, buffer.size)
+                    socket.getOutputStream().write(buffer.reversedArray())
+                    socket.getOutputStream().flush()
+                }
+            }
+
+            HttpConnectProxy(
+                port = 0,
+                connector = HttpConnectProxy.Connector { host, port, _ ->
+                    Socket().apply { connect(InetSocketAddress(host, port), 2_000) }
+                }
+            ).use { proxy ->
+                proxy.start(socksHost = "127.0.0.1", socksPort = 10808)
+                Socket("127.0.0.1", proxy.boundPort).use { client ->
+                    client.soTimeout = 2_000
+                    client.getOutputStream().write(
+                        "CONNECT 127.0.0.1:$targetPort HTTP/1.1\r\nHost: 127.0.0.1:$targetPort\r\n\r\n"
+                            .toByteArray(Charsets.ISO_8859_1)
+                    )
+                    client.getOutputStream().flush()
+
+                    val response = readHeaders(client)
+                    assertTrue(response.startsWith("HTTP/1.1 200"))
+
+                    client.getOutputStream().write(byteArrayOf(1, 2, 3, 4))
+                    client.getOutputStream().flush()
+
+                    assertEquals(listOf<Byte>(4, 3, 2, 1), client.getInputStream().readNBytes(4).toList())
+                }
+            }
+
+            targetThread.join(2_000)
+        }
+    }
+
+    private fun readHeaders(socket: Socket): String {
+        val bytes = mutableListOf<Byte>()
+        val input = socket.getInputStream()
+        while (!bytes.endsWithHeaderTerminator()) {
+            val value = input.read()
+            if (value < 0) break
+            bytes.add(value.toByte())
+        }
+        return bytes.toByteArray().toString(Charsets.ISO_8859_1)
+    }
+
+    private fun List<Byte>.endsWithHeaderTerminator(): Boolean {
+        return size >= 4 &&
+                this[size - 4] == '\r'.code.toByte() &&
+                this[size - 3] == '\n'.code.toByte() &&
+                this[size - 2] == '\r'.code.toByte() &&
+                this[size - 1] == '\n'.code.toByte()
+    }
+}


### PR DESCRIPTION
## Summary
- switch Windows desktop proxy mode to expose HTTP/HTTPS through local CONNECT proxy
- set and restore WinHTTP proxy during Windows Olcbox sessions
- keep SOCKS proxy support for apps that use SOCKS directly
- add fallback to cached olcrtc native binary if bundled resource lookup fails

## Testing
- ./gradlew.bat :sharedUI:jvmTest
- ./gradlew.bat :sharedUI:jvmTest :desktopApp:packageMsi