### PR TITLE
fix(desktop): exit application on window close when system tray is unavailable

### DIFF
--- a/desktopApp/src/main/kotlin/main.kt
+++ b/desktopApp/src/main/kotlin/main.kt
@@ -279,7 +279,12 @@ fun main(args: Array<String>) = application {
         visible = isWindowVisible,
         state = rememberWindowState(width = 430.dp, height = 780.dp),
         onCloseRequest = {
-            isWindowVisible = false
+            if (java.awt.SystemTray.isSupported()) {
+                isWindowVisible = false
+            } else {
+                dependencies.close()
+                exitApplication()
+            }
         },
     ) {
         window.minimumSize = Dimension(350, 600)


### PR DESCRIPTION
## Summary

On Wayland compositors (Niri, Sway, Hyprland, etc.) `java.awt.SystemTray` is not supported — `SystemTray.isSupported()` returns `false` even when XWayland is running, because there is no X11 system tray window (`_NET_SYSTEM_TRAY_S0`) on the Wayland side.

The current `onCloseRequest` handler just sets `isWindowVisible = false`, which hides the window but keeps the process alive. With no tray icon visible, the user has no way to reopen or quit the app — it silently sits in the background.

**Fix:** check `SystemTray.isSupported()` in `onCloseRequest`. If the tray is available, hide the window as before. If not, call `dependencies.close()` and `exitApplication()` so the process exits cleanly.

```kotlin
onCloseRequest = {
    if (java.awt.SystemTray.isSupported()) {
        isWindowVisible = false
    } else {
        dependencies.close()
        exitApplication()
    }
},
```

## Test plan

- [x] On X11 / tray-capable environment: closing the window hides it, tray icon remains
- [x] On Wayland (Niri): closing the window exits the process cleanly, no zombie process left behind