### PR TITLE
fix(ios): keep SOCKS proxy alive in background and auto-reconnect

### DIFF
--- a/iosApp/iosApp/SwiftOlcRtcManager.swift
+++ b/iosApp/iosApp/SwiftOlcRtcManager.swift
@@ -10,6 +10,7 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
     private var mobileLogWriter: MobileLogWriterAdapter?
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
     private let lock = NSLock()
+    private let keepAlive = SilentAudioKeepAlive()
 
     func setLogWriter(writer: IosLogWriter?) {
         lock.lock()
@@ -59,11 +60,18 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         guard ready else {
             MobileStop()
             endBackgroundTaskIfNeeded()
-            deactivatePlaybackSession()
+            keepAlive.stop(log: makeLogger())
             return IosBridgeResult(success: false, message: error?.localizedDescription ?? "olcRTC start timed out")
         }
 
-        activatePlaybackSession()
+        // Real background survival: the `audio` UIBackgroundMode only keeps the app
+        // alive while it is *actually producing audio*. Activating an AVAudioSession
+        // without output (the previous behaviour) let iOS suspend the process after
+        // the beginBackgroundTask grace period (~30s), which froze the Go runtime and
+        // killed the SOCKS/WebRTC transport. Playing a continuous (inaudible) buffer
+        // keeps the audio route active, so the SOCKS proxy keeps running in the
+        // background until the user stops it.
+        keepAlive.start(log: makeLogger())
         beginBackgroundTaskIfNeeded()
         return IosBridgeResult(success: true, message: nil)
     }
@@ -73,7 +81,7 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         defer { lock.unlock() }
         MobileStop()
         endBackgroundTaskIfNeeded()
-        deactivatePlaybackSession()
+        keepAlive.stop(log: makeLogger())
     }
 
     func isRunning() -> Bool {
@@ -169,6 +177,19 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         return Int(UInt16(bigEndian: boundAddr.sin_port))
     }
 
+    private func makeLogger() -> (String) -> Void {
+        return { [weak self] message in
+            self?.log(message)
+        }
+    }
+
+    private func log(_ message: String) {
+        lock.lock()
+        let writer = logWriter
+        lock.unlock()
+        writer?.writeLog(message: message)
+    }
+
     private func beginBackgroundTaskIfNeeded() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -200,36 +221,6 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         }
     }
 
-    private func activatePlaybackSession() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-
-            do {
-                let session = AVAudioSession.sharedInstance()
-                try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
-                try session.setActive(true)
-            } catch {
-                self.lock.lock()
-                let writer = self.logWriter
-                self.lock.unlock()
-                writer?.writeLog(message: "iOS playback background mode unavailable: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    private func deactivatePlaybackSession() {
-        DispatchQueue.main.async { [weak self] in
-            do {
-                try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-            } catch {
-                self?.lock.lock()
-                let writer = self?.logWriter
-                self?.lock.unlock()
-                writer?.writeLog(message: "iOS playback session cleanup failed: \(error.localizedDescription)")
-            }
-        }
-    }
-
     private func endBackgroundTaskIfNeeded() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -243,6 +234,202 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
             guard task != .invalid else { return }
             UIApplication.shared.endBackgroundTask(task)
             writer?.writeLog(message: "iOS background task ended")
+        }
+    }
+}
+
+/// Keeps the app alive in the background by continuously rendering an inaudible
+/// audio buffer through an active `AVAudioSession`. Combined with the `audio`
+/// entry in `UIBackgroundModes` (Info.plist), this prevents iOS from suspending
+/// the process, which would otherwise freeze the Go/WebRTC runtime and drop the
+/// local SOCKS proxy after the short `beginBackgroundTask` grace period.
+///
+/// It also re-arms itself after audio interruptions (phone calls, other apps),
+/// route changes (headphones, Bluetooth) and media-services resets, so a
+/// transient audio event cannot silently kill background execution.
+private final class SilentAudioKeepAlive: NSObject, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "io.olcbox.keepalive")
+    private var engine: AVAudioEngine?
+    private var player: AVAudioPlayerNode?
+    private var running = false
+    private var log: ((String) -> Void)?
+
+    // Amplitude of the keep-alive tone. Inaudible (~ -70 dBFS) but non-zero so the
+    // output route is genuinely "producing audio". If a device still suspends the
+    // app in the background, raise this slightly (e.g. 0.001).
+    private let amplitude: Float = 0.0003
+    private let sampleRate: Double = 44_100
+    private let toneHz: Float = 50
+
+    func start(log: @escaping (String) -> Void) {
+        queue.async {
+            self.log = log
+            guard !self.running else { return }
+            self.registerObservers()
+            if self.activate() {
+                self.running = true
+            }
+        }
+    }
+
+    func stop(log: @escaping (String) -> Void) {
+        queue.async {
+            self.log = log
+            guard self.running else { return }
+            self.running = false
+            self.unregisterObservers()
+            self.teardownEngine()
+            do {
+                try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+            } catch {
+                log("iOS keep-alive session cleanup failed: \(error.localizedDescription)")
+            }
+            log("iOS keep-alive audio stopped")
+        }
+    }
+
+    // MARK: - Engine lifecycle (always on `queue`)
+
+    private func activate() -> Bool {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+
+            guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1),
+                  let buffer = makeBuffer(format: format) else {
+                log?("iOS keep-alive buffer allocation failed")
+                return false
+            }
+
+            let engine = AVAudioEngine()
+            let player = AVAudioPlayerNode()
+            engine.attach(player)
+            engine.connect(player, to: engine.mainMixerNode, format: format)
+            try engine.start()
+            player.scheduleBuffer(buffer, at: nil, options: [.loops], completionHandler: nil)
+            player.play()
+
+            self.engine = engine
+            self.player = player
+            log?("iOS keep-alive audio active; SOCKS keeps running in background")
+            return true
+        } catch {
+            log?("iOS keep-alive audio failed: \(error.localizedDescription)")
+            teardownEngine()
+            return false
+        }
+    }
+
+    private func makeBuffer(format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frames = AVAudioFrameCount(sampleRate) // 1 second, looped forever
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else { return nil }
+        buffer.frameLength = frames
+        guard let channel = buffer.floatChannelData?[0] else { return buffer }
+
+        if amplitude <= 0 {
+            memset(channel, 0, Int(frames) * MemoryLayout<Float>.size)
+            return buffer
+        }
+
+        let step = 2.0 * Float.pi * toneHz / Float(sampleRate)
+        var phase: Float = 0
+        for i in 0..<Int(frames) {
+            channel[i] = sinf(phase) * amplitude
+            phase += step
+            if phase > 2 * Float.pi { phase -= 2 * Float.pi }
+        }
+        return buffer
+    }
+
+    private func teardownEngine() {
+        player?.stop()
+        engine?.stop()
+        if let player, let engine {
+            engine.detach(player)
+        }
+        player = nil
+        engine = nil
+    }
+
+    private func restart(reason: String) {
+        queue.async {
+            guard self.running else { return }
+            self.log?("iOS keep-alive restarting audio (\(reason))")
+            self.teardownEngine()
+            if !self.activate() {
+                self.queue.asyncAfter(deadline: .now() + 1.0) {
+                    guard self.running else { return }
+                    _ = self.activate()
+                }
+            }
+        }
+    }
+
+    // MARK: - Notifications
+
+    private func registerObservers() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(handleInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleMediaReset(_:)),
+            name: AVAudioSession.mediaServicesWereResetNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleEngineConfigChange(_:)),
+            name: .AVAudioEngineConfigurationChange,
+            object: nil
+        )
+    }
+
+    private func unregisterObservers() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleInterruption(_ note: Notification) {
+        guard let info = note.userInfo,
+              let raw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: raw) else { return }
+
+        switch type {
+        case .began:
+            log?("iOS keep-alive: audio interrupted")
+        case .ended:
+            restart(reason: "interruption ended")
+        @unknown default:
+            break
+        }
+    }
+
+    @objc private func handleRouteChange(_ note: Notification) {
+        queue.async {
+            guard self.running, self.engine?.isRunning != true else { return }
+            self.restart(reason: "audio route change")
+        }
+    }
+
+    @objc private func handleMediaReset(_ note: Notification) {
+        restart(reason: "media services reset")
+    }
+
+    @objc private func handleEngineConfigChange(_ note: Notification) {
+        queue.async {
+            guard self.running, self.engine?.isRunning != true else { return }
+            self.restart(reason: "engine configuration change")
         }
     }
 }

--- a/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
+++ b/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
@@ -3,14 +3,17 @@ package org.olcbox.app.vpn
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,13 +51,27 @@ class IosVpnManager(
     private var operationJob: Job? = null
     private var generation = 0L
 
+    // Auto-reconnect state. The iOS transport (Go/WebRTC) does not restart ICE on
+    // its own, so when the underlying connection drops (network migration, the app
+    // being briefly suspended, TURN failures) we detect it and rebuild the SOCKS
+    // session ourselves — mirroring what OlcboxVpnService does on Android.
+    private var desiredConnected = false
+    private var watchdogJob: Job? = null
+    private var reconnectJob: Job? = null
+    private var reconnectAttempt = 0
+    private val timeSource = TimeSource.Monotonic
+    private var lastReadyMark: TimeSource.Monotonic.ValueTimeMark? = null
+
     init {
         olcRtcBridge.setLogWriter(object : IosLogWriter {
             override fun writeLog(message: String) {
                 message
                     .trim()
                     .takeIf { it.isNotBlank() }
-                    ?.let { addLog("rtc: $it") }
+                    ?.let {
+                        addLog("rtc: $it")
+                        handleRtcLine(it)
+                    }
             }
         })
     }
@@ -62,6 +79,9 @@ class IosVpnManager(
     override fun needsPermission(): Boolean = false
 
     override fun startVpn() {
+        desiredConnected = true
+        reconnectAttempt = 0
+        reconnectJob?.cancel()
         val requestedGeneration = ++generation
         operationJob = scope.launch {
             mutex.withLock {
@@ -85,6 +105,9 @@ class IosVpnManager(
     }
 
     override fun stopVpn() {
+        desiredConnected = false
+        watchdogJob?.cancel()
+        reconnectJob?.cancel()
         generation++
         operationJob = scope.launch {
             mutex.withLock {
@@ -124,6 +147,9 @@ class IosVpnManager(
     }
 
     fun close() {
+        desiredConnected = false
+        watchdogJob?.cancel()
+        reconnectJob?.cancel()
         generation++
         runCatching { olcRtcBridge.setLogWriter(null) }
         runCatching { olcRtcBridge.stop() }
@@ -160,6 +186,9 @@ class IosVpnManager(
         if (result.success) {
             setStatus(VpnStatus.Connected)
             addLog("iOS SOCKS ready on 127.0.0.1:${socksSettings.port}")
+            reconnectAttempt = 0
+            lastReadyMark = timeSource.markNow()
+            startWatchdog()
         } else {
             val message = result.message ?: "olcRTC start failed"
             setStatus(VpnStatus.Error(message))
@@ -196,6 +225,106 @@ class IosVpnManager(
         }.getOrElse {
             IosBridgeResult(success = false, message = it.message)
         }
+    }
+
+    /**
+     * Parses olcRTC log lines to detect transport health. The native layer never
+     * performs an ICE restart, so a dropped connection stays dead until we rebuild
+     * it. We treat "connected/listening" markers as healthy and "failed/closed/
+     * broken pipe" markers as a lost transport that must be reconnected.
+     */
+    private fun handleRtcLine(line: String) {
+        if (!desiredConnected) return
+        val lower = line.lowercase()
+
+        if (lower.contains("socks5 server listening") ||
+            lower.contains("ice connection state changed: connected") ||
+            lower.contains("peer connection state changed: connected")
+        ) {
+            reconnectAttempt = 0
+            lastReadyMark = timeSource.markNow()
+            return
+        }
+
+        val transportLost = lower.contains("ice connection state changed: failed") ||
+            lower.contains("peer connection state changed: failed") ||
+            lower.contains("ice connection state changed: closed") ||
+            lower.contains("peer connection state changed: closed") ||
+            lower.contains("read/write on closed pipe") ||
+            lower.contains("use of closed network connection")
+
+        if (transportLost) {
+            // Ignore teardown noise that immediately follows a fresh (re)connect.
+            val recentlyReady = lastReadyMark
+                ?.elapsedNow()
+                ?.inWholeMilliseconds
+                ?.let { it < POST_CONNECT_GRACE_MS }
+                ?: false
+            if (recentlyReady) return
+            scheduleReconnect("RTC transport lost")
+        }
+    }
+
+    /**
+     * Periodically verifies the SOCKS transport is still up while the user wants to
+     * stay connected, catching silent deaths that produce no log marker.
+     */
+    private fun startWatchdog() {
+        watchdogJob?.cancel()
+        watchdogJob = scope.launch {
+            while (isActive && desiredConnected) {
+                delay(WATCHDOG_INTERVAL_MS)
+                if (!desiredConnected) break
+                val stalled = _status.value is VpnStatus.Connected &&
+                    reconnectJob?.isActive != true &&
+                    !olcRtcBridge.isRunning()
+                if (stalled) {
+                    addLog("Watchdog: iOS SOCKS transport is down")
+                    scheduleReconnect("transport stopped")
+                }
+            }
+        }
+    }
+
+    private fun scheduleReconnect(reason: String) {
+        if (!desiredConnected) return
+        if (reconnectJob?.isActive == true) return
+        val status = _status.value
+        if (status !is VpnStatus.Connected && status !is VpnStatus.Reconnecting) return
+
+        reconnectJob = scope.launch {
+            setStatus(VpnStatus.Reconnecting)
+            addLog("Auto-reconnect requested ($reason)")
+
+            // Keep retrying with exponential backoff until we reconnect or the user
+            // turns the connection off. A single failed attempt (e.g. no network yet)
+            // must not give up — that is what left the transport dead before.
+            while (desiredConnected && isActive) {
+                val delayMs = nextReconnectDelay()
+                addLog("Reconnecting iOS SOCKS in ${delayMs / 1000}s")
+                delay(delayMs)
+                if (!desiredConnected) return@launch
+
+                val requestedGeneration = ++generation
+                val reconnected = mutex.withLock {
+                    if (requestedGeneration != generation || !desiredConnected) return@withLock false
+                    stopOlcRtc()
+                    startOlcRtc(requestedGeneration, isRestart = true)
+                    _status.value is VpnStatus.Connected
+                }
+
+                if (reconnected || !desiredConnected) return@launch
+                // startOlcRtc reports failure via Error status; keep the user-facing
+                // state as Reconnecting so the retry loop stays coherent.
+                if (_status.value !is VpnStatus.Reconnecting) setStatus(VpnStatus.Reconnecting)
+            }
+        }
+    }
+
+    private fun nextReconnectDelay(): Long {
+        val multiplier = 1L shl reconnectAttempt.coerceAtMost(MAX_RECONNECT_BACKOFF_POWER)
+        reconnectAttempt++
+        return (RECONNECT_BASE_DELAY_MS * multiplier).coerceAtMost(RECONNECT_MAX_DELAY_MS)
     }
 
     private fun setStatus(status: VpnStatus) {
@@ -276,6 +405,11 @@ class IosVpnManager(
         const val MAX_LOG_LINES = 500
         const val CHECK_TIMEOUT_MS = 8_000L
         const val HTTP_PING_URL = "https://www.google.com/generate_204"
+        const val WATCHDOG_INTERVAL_MS = 10_000L
+        const val RECONNECT_BASE_DELAY_MS = 2_000L
+        const val RECONNECT_MAX_DELAY_MS = 30_000L
+        const val MAX_RECONNECT_BACKOFF_POWER = 3
+        const val POST_CONNECT_GRACE_MS = 4_000L
         const val CREDENTIAL_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"
     }
 }


### PR DESCRIPTION
## Problem

On iOS the app only raises a local SOCKS proxy (no Network Extension), and it dropped after ~1 minute in the background:

- The `audio` background mode was declared but no audio was ever produced, so iOS suspended the app ~30s after backgrounding, freezing the transport and killing the SOCKS proxy.
- There was no reconnect — once the transport died it stayed dead until a manual restart.

## Changes

- **Background keep-alive** (`SwiftOlcRtcManager.swift`): play a continuous inaudible buffer through an active `AVAudioSession` so the audio route stays live and the proxy keeps running in the background. Re-armed after audio interruptions, route changes and media-services resets.
- **Auto-reconnect** (`IosVpnManager.kt`): detect a lost transport from olcRTC log markers and an `isRunning()` watchdog, then rebuild the SOCKS session with exponential backoff until it recovers — mirroring the Android service.

## Testing

Verified on a physical iPhone 11 with Shadowrocket routed through the local SOCKS proxy: the connection stays stable in the background and no longer drops after ~1 minute.

## Notes

- No signing / entitlement / `Info.plist` changes; the existing `audio` background mode is reused.
- Not a full system VPN (that would need a Network Extension); this keeps the existing SOCKS + external-proxy model reliable in the background.
