### PR TITLE
route Android TUN UDP through SOCKS relay

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -76,3 +76,9 @@ jobs:
           export ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"
           export ANDROID_NDK_ROOT="${ANDROID_NDK_HOME}"
           ./gradlew :sharedUI:jvmTest :desktopApp:compileKotlin :androidApp:assembleDebug --stacktrace
+
+      - name: Upload Android debug APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: Olcbox-android-debug
+          path: olcbox/androidApp/build/outputs/apk/debug/*.apk

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: alananisimov/olcrtc
+          repository: cyber-debug/olcrtc
           ref: master
           path: olcrtc
           submodules: recursive
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -209,7 +209,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -262,7 +262,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -334,7 +334,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -458,7 +458,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -808,7 +808,7 @@ class OlcboxVpnService : VpnService() {
             socks5:
               address: ${socksConnectHost()}
               port: $socksListenPort
-              udp: 'tcp'
+              udp: 'udp'
               pipeline: false
               username: '$socksUsername'
               password: '$socksPassword'


### PR DESCRIPTION
## Summary
- routes Android TUN UDP through the SOCKS5 UDP relay instead of forcing UDP over TCP
- points CI at the UDP-enabled olcrtc fork while the upstream olcrtc UDP PR is pending
- uploads the Android debug APK from PR checks as an artifact

## Compatibility note
This PR is not ready for regular app users yet. It depends on the matching UDP transport changes in olcrtc and should stay draft until that dependency is merged or otherwise vendored cleanly.

## Validation
- GitHub Actions PR Checks passed in cyber-debug/olcbox
- Android debug APK artifact was uploaded successfully

Related dependency: https://github.com/openlibrecommunity/olcrtc/pull/122