### PR TITLE
Исправить сетевую стабильность и добавить routing policy

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -76,3 +76,9 @@ jobs:
           export ANDROID_NDK_HOME="${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}"
           export ANDROID_NDK_ROOT="${ANDROID_NDK_HOME}"
           ./gradlew :sharedUI:jvmTest :desktopApp:compileKotlin :androidApp:assembleDebug --stacktrace
+
+      - name: Upload Android debug APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: Olcbox-android-debug
+          path: olcbox/androidApp/build/outputs/apk/debug/*.apk

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: pr-checks-${{ github.event.pull_request.number }}
+  group: pr-checks-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -29,7 +30,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: cyber-debug/olcrtc
+          repository: alananisimov/olcrtc
           ref: master
           path: olcrtc
           submodules: recursive

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: alananisimov/olcrtc
+          repository: cyber-debug/olcrtc
           ref: master
           path: olcrtc
           submodules: recursive
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: cyber-debug/olcrtc
+          repository: openlibrecommunity/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -209,7 +209,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: cyber-debug/olcrtc
+          repository: openlibrecommunity/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -262,7 +262,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: cyber-debug/olcrtc
+          repository: openlibrecommunity/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -334,7 +334,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: cyber-debug/olcrtc
+          repository: openlibrecommunity/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -458,7 +458,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: cyber-debug/olcrtc
+          repository: openlibrecommunity/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -209,7 +209,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -262,7 +262,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -334,7 +334,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install Android SDK packages
         run: |
-          sdkmanager "platforms;android-36" "build-tools;36.0.0" "ndk;${ANDROID_NDK_VERSION}"
+          sdkmanager "platforms;android-37" "build-tools;37.0.0" "ndk;${ANDROID_NDK_VERSION}"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -458,7 +458,7 @@ jobs:
       - name: Checkout olcrtc
         uses: actions/checkout@v7
         with:
-          repository: openlibrecommunity/olcrtc
+          repository: cyber-debug/olcrtc
           ref: ${{ needs.release_version.outputs.olcrtc_ref }}
           path: olcrtc
           submodules: recursive

--- a/desktopApp/src/main/kotlin/main.kt
+++ b/desktopApp/src/main/kotlin/main.kt
@@ -114,10 +114,12 @@ private class DesktopAppDependencies {
         deviceIdentityProvider = PersistentDeviceIdentityProvider(locationsDataSource)
     )
     val updateSettingsStore = JvmUpdateSettingsStore()
-    val updateInstaller = JvmUpdateInstaller()
     val socksProxySettingsStore = JvmDesktopSocksProxySettingsStore()
 
     val vpnManager = DesktopVpnManager(locationsRepository)
+    val updateInstaller = JvmUpdateInstaller {
+        vpnManager.subscriptionFetchProxy()
+    }
 
     val homeViewModel = HomeScreenViewModel(
         vpnManager = vpnManager,
@@ -171,7 +173,10 @@ fun main(args: Array<String>) = application {
             if (!manual && !previousSettings.isUpdateCheckDue(checkStartedAt)) return@launch
 
             updateMessage = "Checking ${previousSettings.channel.name.lowercase()}..."
-            val result = dependencies.updateService.check(previousSettings.channel)
+            val result = dependencies.updateService.check(
+                previousSettings.channel,
+                dependencies.vpnManager.subscriptionFetchProxy()
+            )
             val checkedAt = kotlin.time.Clock.System.now().toEpochMilliseconds()
             val checkedSettings = previousSettings.copy(lastCheckAtEpochMs = checkedAt).normalized()
             saveUpdateSettings(checkedSettings)

--- a/docs/routing-policy.md
+++ b/docs/routing-policy.md
@@ -27,9 +27,17 @@ Supported schema:
 Current runtime support:
 
 - `ip_cidr` rules are parsed, normalized, tested, and included in runtime plans.
+- `geoip:private`, `geoip:lan`, and `geoip:local` are expanded into private/reserved IPv4 CIDR rules.
+- `domain`, `domain_suffix`, `geosite`, and `.dat` categories are separated into a resolver-level plan with their original `proxy` or `bypass` action preserved.
 - Android TUN applies bypass `ip_cidr` rules with `VpnService.Builder.excludeRoute` on Android 13+.
 - Linux TUN applies bypass `ip_cidr` rules with high-priority `ip rule to <cidr> lookup main` entries.
 - Windows TUN and system-proxy modes log routing policy state but do not enforce route exclusions yet.
-- `domain`, `domain_suffix`, `geosite`, `geoip`, and `.dat` list references are imported, preserved, summarized, and visible to runtime logs/UI.
+- Android TUN and Linux TUN enable `mapdns`, so DNS answers can be mapped back to hostnames before the SOCKS connection is made.
+- Hostname-based `proxy` rules can use the mapdns/SOCKS hostname path when traffic is already inside the TUN.
+- Hostname-based `bypass` rules still need native direct-route support. Android's `VpnService.Builder` can exclude static IP prefixes, but it cannot dynamically exclude a domain after DNS resolution.
 
-Domain and `.dat` rules need a DNS/mapdns resolver layer before they can be enforced reliably. TUN packet routing sees IP packets; it does not automatically know the original domain. The resolver layer must map DNS answers back to policy decisions before domain/geosite/geoip rules can safely affect routing.
+Limitations:
+
+- Country-wide `geoip` values such as `geoip:ru` need a real GeoIP database or generated CIDR bundle before they can become route-level rules.
+- `geosite` and external `.dat` list references are preserved in the runtime plan, but this PR does not download or parse third-party `.dat` files yet.
+- Apps that use encrypted DNS outside the VPN DNS path, such as DoH/DoT inside the app, may not hit mapdns and therefore may not expose the original domain to the routing layer.

--- a/docs/routing-policy.md
+++ b/docs/routing-policy.md
@@ -1,0 +1,35 @@
+# Subscription Routing Policy
+
+Olcbox accepts an optional `routing` object in imported subscription JSON.
+
+Supported schema:
+
+```json
+{
+  "routing": {
+    "split_tunnel": "full_tunnel",
+    "dat_lists": [
+      {
+        "name": "geosite",
+        "url": "https://example.com/geosite.dat",
+        "categories": ["geosite:ru", "geosite:youtube"],
+        "action": "bypass"
+      }
+    ],
+    "rules": [
+      { "type": "domain_suffix", "value": "youtube.com", "action": "proxy" },
+      { "type": "ip_cidr", "value": "10.0.0.0/8", "action": "bypass" }
+    ]
+  }
+}
+```
+
+Current runtime support:
+
+- `ip_cidr` rules are parsed, normalized, tested, and included in runtime plans.
+- Android TUN applies bypass `ip_cidr` rules with `VpnService.Builder.excludeRoute` on Android 13+.
+- Linux TUN applies bypass `ip_cidr` rules with high-priority `ip rule to <cidr> lookup main` entries.
+- Windows TUN and system-proxy modes log routing policy state but do not enforce route exclusions yet.
+- `domain`, `domain_suffix`, `geosite`, `geoip`, and `.dat` list references are imported, preserved, summarized, and visible to runtime logs/UI.
+
+Domain and `.dat` rules need a DNS/mapdns resolver layer before they can be enforced reliably. TUN packet routing sees IP packets; it does not automatically know the original domain. The resolver layer must map DNS answers back to policy decisions before domain/geosite/geoip rules can safely affect routing.

--- a/iosApp/iosApp/SwiftOlcRtcManager.swift
+++ b/iosApp/iosApp/SwiftOlcRtcManager.swift
@@ -10,6 +10,7 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
     private var mobileLogWriter: MobileLogWriterAdapter?
     private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
     private let lock = NSLock()
+    private let keepAlive = SilentAudioKeepAlive()
 
     func setLogWriter(writer: IosLogWriter?) {
         lock.lock()
@@ -59,11 +60,18 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         guard ready else {
             MobileStop()
             endBackgroundTaskIfNeeded()
-            deactivatePlaybackSession()
+            keepAlive.stop(log: makeLogger())
             return IosBridgeResult(success: false, message: error?.localizedDescription ?? "olcRTC start timed out")
         }
 
-        activatePlaybackSession()
+        // Real background survival: the `audio` UIBackgroundMode only keeps the app
+        // alive while it is *actually producing audio*. Activating an AVAudioSession
+        // without output (the previous behaviour) let iOS suspend the process after
+        // the beginBackgroundTask grace period (~30s), which froze the Go runtime and
+        // killed the SOCKS/WebRTC transport. Playing a continuous (inaudible) buffer
+        // keeps the audio route active, so the SOCKS proxy keeps running in the
+        // background until the user stops it.
+        keepAlive.start(log: makeLogger())
         beginBackgroundTaskIfNeeded()
         return IosBridgeResult(success: true, message: nil)
     }
@@ -73,7 +81,7 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         defer { lock.unlock() }
         MobileStop()
         endBackgroundTaskIfNeeded()
-        deactivatePlaybackSession()
+        keepAlive.stop(log: makeLogger())
     }
 
     func isRunning() -> Bool {
@@ -169,6 +177,19 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         return Int(UInt16(bigEndian: boundAddr.sin_port))
     }
 
+    private func makeLogger() -> (String) -> Void {
+        return { [weak self] message in
+            self?.log(message)
+        }
+    }
+
+    private func log(_ message: String) {
+        lock.lock()
+        let writer = logWriter
+        lock.unlock()
+        writer?.writeLog(message: message)
+    }
+
     private func beginBackgroundTaskIfNeeded() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -200,36 +221,6 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
         }
     }
 
-    private func activatePlaybackSession() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-
-            do {
-                let session = AVAudioSession.sharedInstance()
-                try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
-                try session.setActive(true)
-            } catch {
-                self.lock.lock()
-                let writer = self.logWriter
-                self.lock.unlock()
-                writer?.writeLog(message: "iOS playback background mode unavailable: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    private func deactivatePlaybackSession() {
-        DispatchQueue.main.async { [weak self] in
-            do {
-                try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-            } catch {
-                self?.lock.lock()
-                let writer = self?.logWriter
-                self?.lock.unlock()
-                writer?.writeLog(message: "iOS playback session cleanup failed: \(error.localizedDescription)")
-            }
-        }
-    }
-
     private func endBackgroundTaskIfNeeded() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -243,6 +234,202 @@ final class SwiftOlcRtcManager: NSObject, @unchecked Sendable, IosOlcRtcBridge {
             guard task != .invalid else { return }
             UIApplication.shared.endBackgroundTask(task)
             writer?.writeLog(message: "iOS background task ended")
+        }
+    }
+}
+
+/// Keeps the app alive in the background by continuously rendering an inaudible
+/// audio buffer through an active `AVAudioSession`. Combined with the `audio`
+/// entry in `UIBackgroundModes` (Info.plist), this prevents iOS from suspending
+/// the process, which would otherwise freeze the Go/WebRTC runtime and drop the
+/// local SOCKS proxy after the short `beginBackgroundTask` grace period.
+///
+/// It also re-arms itself after audio interruptions (phone calls, other apps),
+/// route changes (headphones, Bluetooth) and media-services resets, so a
+/// transient audio event cannot silently kill background execution.
+private final class SilentAudioKeepAlive: NSObject, @unchecked Sendable {
+    private let queue = DispatchQueue(label: "io.olcbox.keepalive")
+    private var engine: AVAudioEngine?
+    private var player: AVAudioPlayerNode?
+    private var running = false
+    private var log: ((String) -> Void)?
+
+    // Amplitude of the keep-alive tone. Inaudible (~ -70 dBFS) but non-zero so the
+    // output route is genuinely "producing audio". If a device still suspends the
+    // app in the background, raise this slightly (e.g. 0.001).
+    private let amplitude: Float = 0.0003
+    private let sampleRate: Double = 44_100
+    private let toneHz: Float = 50
+
+    func start(log: @escaping (String) -> Void) {
+        queue.async {
+            self.log = log
+            guard !self.running else { return }
+            self.registerObservers()
+            if self.activate() {
+                self.running = true
+            }
+        }
+    }
+
+    func stop(log: @escaping (String) -> Void) {
+        queue.async {
+            self.log = log
+            guard self.running else { return }
+            self.running = false
+            self.unregisterObservers()
+            self.teardownEngine()
+            do {
+                try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+            } catch {
+                log("iOS keep-alive session cleanup failed: \(error.localizedDescription)")
+            }
+            log("iOS keep-alive audio stopped")
+        }
+    }
+
+    // MARK: - Engine lifecycle (always on `queue`)
+
+    private func activate() -> Bool {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+
+            guard let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1),
+                  let buffer = makeBuffer(format: format) else {
+                log?("iOS keep-alive buffer allocation failed")
+                return false
+            }
+
+            let engine = AVAudioEngine()
+            let player = AVAudioPlayerNode()
+            engine.attach(player)
+            engine.connect(player, to: engine.mainMixerNode, format: format)
+            try engine.start()
+            player.scheduleBuffer(buffer, at: nil, options: [.loops], completionHandler: nil)
+            player.play()
+
+            self.engine = engine
+            self.player = player
+            log?("iOS keep-alive audio active; SOCKS keeps running in background")
+            return true
+        } catch {
+            log?("iOS keep-alive audio failed: \(error.localizedDescription)")
+            teardownEngine()
+            return false
+        }
+    }
+
+    private func makeBuffer(format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let frames = AVAudioFrameCount(sampleRate) // 1 second, looped forever
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else { return nil }
+        buffer.frameLength = frames
+        guard let channel = buffer.floatChannelData?[0] else { return buffer }
+
+        if amplitude <= 0 {
+            memset(channel, 0, Int(frames) * MemoryLayout<Float>.size)
+            return buffer
+        }
+
+        let step = 2.0 * Float.pi * toneHz / Float(sampleRate)
+        var phase: Float = 0
+        for i in 0..<Int(frames) {
+            channel[i] = sinf(phase) * amplitude
+            phase += step
+            if phase > 2 * Float.pi { phase -= 2 * Float.pi }
+        }
+        return buffer
+    }
+
+    private func teardownEngine() {
+        player?.stop()
+        engine?.stop()
+        if let player, let engine {
+            engine.detach(player)
+        }
+        player = nil
+        engine = nil
+    }
+
+    private func restart(reason: String) {
+        queue.async {
+            guard self.running else { return }
+            self.log?("iOS keep-alive restarting audio (\(reason))")
+            self.teardownEngine()
+            if !self.activate() {
+                self.queue.asyncAfter(deadline: .now() + 1.0) {
+                    guard self.running else { return }
+                    _ = self.activate()
+                }
+            }
+        }
+    }
+
+    // MARK: - Notifications
+
+    private func registerObservers() {
+        let center = NotificationCenter.default
+        center.addObserver(
+            self,
+            selector: #selector(handleInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleMediaReset(_:)),
+            name: AVAudioSession.mediaServicesWereResetNotification,
+            object: nil
+        )
+        center.addObserver(
+            self,
+            selector: #selector(handleEngineConfigChange(_:)),
+            name: .AVAudioEngineConfigurationChange,
+            object: nil
+        )
+    }
+
+    private func unregisterObservers() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleInterruption(_ note: Notification) {
+        guard let info = note.userInfo,
+              let raw = info[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: raw) else { return }
+
+        switch type {
+        case .began:
+            log?("iOS keep-alive: audio interrupted")
+        case .ended:
+            restart(reason: "interruption ended")
+        @unknown default:
+            break
+        }
+    }
+
+    @objc private func handleRouteChange(_ note: Notification) {
+        queue.async {
+            guard self.running, self.engine?.isRunning != true else { return }
+            self.restart(reason: "audio route change")
+        }
+    }
+
+    @objc private func handleMediaReset(_ note: Notification) {
+        restart(reason: "media services reset")
+    }
+
+    @objc private func handleEngineConfigChange(_ note: Notification) {
+        queue.async {
+            guard self.running, self.engine?.isRunning != true else { return }
+            self.restart(reason: "engine configuration change")
         }
     }
 }

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -808,7 +808,7 @@ class OlcboxVpnService : VpnService() {
             socks5:
               address: ${socksConnectHost()}
               port: $socksListenPort
-              udp: 'tcp'
+              udp: 'udp'
               pipeline: false
               username: '$socksUsername'
               password: '$socksPassword'

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -65,6 +65,7 @@ import java.io.DataInputStream
 import java.io.DataOutputStream
 import java.io.File
 import java.net.InetSocketAddress
+import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
 import kotlin.concurrent.thread
@@ -749,7 +750,9 @@ class OlcboxVpnService : VpnService() {
 
         var applied = 0
         routingPlan.bypassIpv4Cidrs.forEach { cidr ->
-            val prefix = runCatching { IpPrefix("${cidr.address}/${cidr.prefixLength}") }.getOrNull()
+            val prefix = runCatching {
+                IpPrefix(InetAddress.getByName(cidr.address), cidr.prefixLength)
+            }.getOrNull()
             if (prefix == null) {
                 addLog("Routing policy skipped invalid CIDR ${cidr.value}")
                 return@forEach

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
+import android.net.IpPrefix
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
@@ -41,6 +42,8 @@ import org.olcbox.app.data.datasource.LocationsDataSourceImpl
 import org.olcbox.app.data.datasource.LocationsRepositoryImpl
 import org.olcbox.app.data.identity.PersistentDeviceIdentityProvider
 import org.olcbox.app.data.model.LocationConfig
+import org.olcbox.app.data.routing.RoutingPolicyPlanner
+import org.olcbox.app.data.routing.RoutingPolicyRuntimePlan
 import org.olcbox.app.data.repository.LocationsRepository
 import org.olcbox.app.vpn.AndroidConnectionMode
 import org.olcbox.app.vpn.AndroidSocksProxySettings
@@ -436,6 +439,7 @@ class OlcboxVpnService : VpnService() {
 
                     val active = repository.getActiveLocation()
                     val location = active?.location?.normalized()
+                    val routingPlan = RoutingPolicyPlanner.plan(active?.routing)
                     if (location == null || !location.isComplete()) {
                         setStatus(VpnStatus.Error("No active location"))
                         updateNotification("Add a location first")
@@ -446,7 +450,7 @@ class OlcboxVpnService : VpnService() {
                     if (isMigration && !forceFullRestart && canReconnectTransportInPlace()) {
                         reconnectTransport(location, requestedGeneration)
                     } else {
-                        startFullTunnel(location, requestedGeneration, isMigration, isRestart)
+                        startFullTunnel(location, routingPlan, requestedGeneration, isMigration, isRestart)
                     }
                 }
             } finally {
@@ -491,6 +495,7 @@ class OlcboxVpnService : VpnService() {
 
     private suspend fun startFullTunnel(
         location: LocationConfig,
+        routingPlan: RoutingPolicyRuntimePlan,
         requestedGeneration: Long,
         isMigration: Boolean,
         isRestart: Boolean
@@ -544,7 +549,7 @@ class OlcboxVpnService : VpnService() {
         delay(TUNNEL_HANDOFF_DELAY_MS)
         coroutineContext.ensureActive()
 
-        val pfd = establishSystemVpnTunnel()
+        val pfd = establishSystemVpnTunnel(routingPlan)
         if (pfd == null) {
             stopMobileAndWait()
             return
@@ -699,17 +704,17 @@ class OlcboxVpnService : VpnService() {
         }
     }
 
-    private fun establishSystemVpnTunnel(): ParcelFileDescriptor? {
+    private fun establishSystemVpnTunnel(routingPlan: RoutingPolicyRuntimePlan): ParcelFileDescriptor? {
         return try {
             val builder = Builder()
                 .setSession("Olcbox VPN")
                 .setMtu(TUN_MTU)
                 .addAddress(TUN_IPV4_ADDRESS, IPV4_PREFIX_LENGTH)
-                .addRoute("0.0.0.0", 0)
                 .addDnsServer(MAPDNS_ADDRESS)
                 .setBlocking(true)
 
             if (!applySplitTunneling(builder)) return null
+            applyRoutingPolicyRoutes(builder, routingPlan)
 
             currentNetwork?.let { builder.setUnderlyingNetworks(arrayOf(it)) }
             builder.establish()
@@ -718,6 +723,44 @@ class OlcboxVpnService : VpnService() {
             setStatus(VpnStatus.Error(e.message ?: "VPN establish failed"))
             updateNotification("VPN tunnel error")
             null
+        }
+    }
+
+    private fun applyRoutingPolicyRoutes(builder: Builder, routingPlan: RoutingPolicyRuntimePlan) {
+        builder.addRoute("0.0.0.0", 0)
+        if (!routingPlan.hasPolicy) return
+
+        addLog(routingPlan.summary())
+        if (routingPlan.hasResolverRules) {
+            addLog("Routing policy has domain/.dat rules; Android TUN needs DNS resolver wiring before those can be enforced")
+        }
+        if (routingPlan.proxyIpv4Cidrs.isNotEmpty()) {
+            addLog("Routing policy has ${routingPlan.proxyIpv4Cidrs.size} proxy CIDR rule(s); Android full-tunnel already proxies them")
+        }
+        if (routingPlan.bypassIpv4Cidrs.isEmpty()) return
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            addLog("Routing policy bypass CIDR rules require Android 13+ excludeRoute support")
+            return
+        }
+
+        var applied = 0
+        routingPlan.bypassIpv4Cidrs.forEach { cidr ->
+            val prefix = runCatching { IpPrefix("${cidr.address}/${cidr.prefixLength}") }.getOrNull()
+            if (prefix == null) {
+                addLog("Routing policy skipped invalid CIDR ${cidr.value}")
+                return@forEach
+            }
+            runCatching {
+                builder.excludeRoute(prefix)
+                applied += 1
+            }.onFailure {
+                addLog("Routing policy failed to bypass ${cidr.value}: ${it.message}")
+            }
+        }
+
+        if (applied > 0) {
+            addLog("Routing policy: bypassed $applied CIDR route(s) outside Android VPN")
         }
     }
 

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -731,8 +731,11 @@ class OlcboxVpnService : VpnService() {
         if (!routingPlan.hasPolicy) return
 
         addLog(routingPlan.summary())
-        if (routingPlan.hasResolverRules) {
-            addLog("Routing policy has domain/.dat rules; Android TUN needs DNS resolver wiring before those can be enforced")
+        if (routingPlan.hasMapDnsRules) {
+            addLog("Routing policy mapdns is enabled for domain/geosite/.dat hostname matching")
+            if (routingPlan.bypassDomainRules.isNotEmpty() || routingPlan.bypassDatCategories.isNotEmpty()) {
+                addLog("Routing policy domain bypass rules need native direct-route support; CIDR bypass rules are enforced below")
+            }
         }
         if (routingPlan.proxyIpv4Cidrs.isNotEmpty()) {
             addLog("Routing policy has ${routingPlan.proxyIpv4Cidrs.size} proxy CIDR rule(s); Android full-tunnel already proxies them")

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
@@ -339,7 +339,8 @@ class LocationsRepositoryImpl(
                 storageId = normalizedId,
                 location = location,
                 subscriptionUrl = current?.subscriptionUrl,
-                metadata = current?.metadata
+                metadata = current?.metadata,
+                routing = current?.routing
             )
             val locations = bundle.locations
                 .filterNot { it.storageId == entry.storageId } + entry

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
@@ -329,6 +329,106 @@ data class LocationMetadata(
 }
 
 @Serializable
+enum class RoutingSplitTunnelMode {
+    @SerialName("full_tunnel")
+    FullTunnel,
+
+    @SerialName("proxy_selected")
+    ProxySelected,
+
+    @SerialName("bypass_selected")
+    BypassSelected
+}
+
+@Serializable
+enum class RoutingRuleAction {
+    @SerialName("proxy")
+    Proxy,
+
+    @SerialName("bypass")
+    Bypass
+}
+
+@Serializable
+enum class RoutingRuleType {
+    @SerialName("domain")
+    Domain,
+
+    @SerialName("domain_suffix")
+    DomainSuffix,
+
+    @SerialName("ip_cidr")
+    IpCidr,
+
+    @SerialName("geosite")
+    GeoSite,
+
+    @SerialName("geoip")
+    GeoIp
+}
+
+@Serializable
+data class RoutingDatListConfig(
+    val name: String = "",
+    val url: String = "",
+    val categories: List<String> = emptyList(),
+    val action: RoutingRuleAction = RoutingRuleAction.Proxy
+) {
+    fun normalized(): RoutingDatListConfig {
+        return copy(
+            name = name.trim(),
+            url = url.trim(),
+            categories = categories.cleanedRoutingValues()
+        )
+    }
+
+    fun isEmpty(): Boolean {
+        return name.isBlank() && url.isBlank() && categories.isEmpty()
+    }
+}
+
+@Serializable
+data class RoutingRuleConfig(
+    val type: RoutingRuleType = RoutingRuleType.DomainSuffix,
+    val value: String = "",
+    val action: RoutingRuleAction = RoutingRuleAction.Proxy
+) {
+    fun normalized(): RoutingRuleConfig {
+        return copy(value = value.trim())
+    }
+
+    fun isEmpty(): Boolean = value.isBlank()
+}
+
+@Serializable
+data class RoutingPolicyConfig(
+    @SerialName("split_tunnel")
+    val splitTunnel: RoutingSplitTunnelMode = RoutingSplitTunnelMode.FullTunnel,
+    @SerialName("dat_lists")
+    val datLists: List<RoutingDatListConfig> = emptyList(),
+    val rules: List<RoutingRuleConfig> = emptyList()
+) {
+    fun normalized(): RoutingPolicyConfig {
+        return copy(
+            datLists = datLists
+                .map { it.normalized() }
+                .filterNot { it.isEmpty() }
+                .distinctBy { "${it.name}|${it.url}|${it.categories.joinToString(",")}|${it.action}" },
+            rules = rules
+                .map { it.normalized() }
+                .filterNot { it.isEmpty() }
+                .distinctBy { "${it.type}|${it.value}|${it.action}" }
+        )
+    }
+
+    fun isEmpty(): Boolean {
+        return splitTunnel == RoutingSplitTunnelMode.FullTunnel &&
+                datLists.isEmpty() &&
+                rules.isEmpty()
+    }
+}
+
+@Serializable
 data class LocationEntry(
     @SerialName("storage_id")
     val storageId: String,
@@ -342,6 +442,7 @@ data class LocationEntry(
     val legacyCarrier: String? = null,
     val transport: LocationTransportConfig? = null,
     val metadata: LocationMetadata? = null,
+    val routing: RoutingPolicyConfig? = null,
     @SerialName("subscriptionUrl")
     val legacySubscriptionUrl: String? = null,
     @SerialName("id")
@@ -418,6 +519,9 @@ data class LocationEntry(
             transport = LocationTransportConfig.from(config),
             metadata = metadata
                 ?.normalized()
+                ?.takeUnless { it.isEmpty() },
+            routing = routing
+                ?.normalized()
                 ?.takeUnless { it.isEmpty() }
         )
     }
@@ -427,7 +531,8 @@ data class LocationEntry(
             storageId: String,
             location: LocationConfig,
             subscriptionUrl: String? = null,
-            metadata: LocationMetadata? = null
+            metadata: LocationMetadata? = null,
+            routing: RoutingPolicyConfig? = null
         ): LocationEntry {
             val config = location.normalized()
             return LocationEntry(
@@ -440,7 +545,8 @@ data class LocationEntry(
                 ),
                 authProvider = config.bypassProvider,
                 transport = LocationTransportConfig.from(config),
-                metadata = metadata
+                metadata = metadata,
+                routing = routing
             ).normalized()
         }
 
@@ -452,6 +558,11 @@ data class LocationEntry(
 
 private fun String?.cleanMetadataValue(): String? {
     return this?.trim()?.takeIf { it.isNotEmpty() }
+}
+
+private fun List<String>.cleanedRoutingValues(): List<String> {
+    return mapNotNull { value -> value.trim().takeIf { it.isNotEmpty() } }
+        .distinct()
 }
 
 @Serializable

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
@@ -6,6 +6,12 @@ import org.olcbox.app.data.model.RoutingRuleConfig
 import org.olcbox.app.data.model.RoutingRuleType
 import org.olcbox.app.data.model.RoutingSplitTunnelMode
 
+data class Ipv4Cidr(
+    val value: String,
+    val address: String,
+    val prefixLength: Int
+)
+
 enum class RoutingDecision {
     Proxy,
     Bypass
@@ -66,19 +72,30 @@ object RoutingPolicyMatcher {
     }
 
     private fun ipv4InCidr(ip: String, cidr: String): Boolean {
-        val separator = cidr.indexOf('/')
-        if (separator <= 0 || separator == cidr.lastIndex) return false
-
-        val network = parseIpv4(cidr.substring(0, separator).trim()) ?: return false
-        val prefix = cidr.substring(separator + 1).trim().toIntOrNull() ?: return false
-        if (prefix !in 0..32) return false
-
+        val parsedCidr = parseIpv4Cidr(cidr) ?: return false
+        val network = parseIpv4(parsedCidr.address) ?: return false
         val address = parseIpv4(ip) ?: return false
-        val mask = if (prefix == 0) 0 else (-1 shl (32 - prefix))
+        val mask = if (parsedCidr.prefixLength == 0) 0 else (-1 shl (32 - parsedCidr.prefixLength))
         return (address and mask) == (network and mask)
     }
 
-    private fun parseIpv4(value: String): Int? {
+    fun parseIpv4Cidr(value: String): Ipv4Cidr? {
+        val cidr = value.trim()
+        val separator = cidr.indexOf('/')
+        if (separator <= 0 || separator == cidr.lastIndex) return null
+
+        val address = cidr.substring(0, separator).trim()
+        val prefix = cidr.substring(separator + 1).trim().toIntOrNull() ?: return null
+        if (prefix !in 0..32 || parseIpv4(address) == null) return null
+
+        return Ipv4Cidr(
+            value = "$address/$prefix",
+            address = address,
+            prefixLength = prefix
+        )
+    }
+
+    fun parseIpv4(value: String): Int? {
         val parts = value.trim().split('.')
         if (parts.size != 4) return null
 

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
@@ -12,12 +12,35 @@ data class Ipv4Cidr(
     val prefixLength: Int
 )
 
+data class DomainRoutingRule(
+    val type: RoutingRuleType,
+    val value: String,
+    val action: RoutingRuleAction
+)
+
 enum class RoutingDecision {
     Proxy,
     Bypass
 }
 
 object RoutingPolicyMatcher {
+    private val privateIpv4Cidrs = listOf(
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.0.2.0/24",
+        "192.168.0.0/16",
+        "198.18.0.0/15",
+        "198.51.100.0/24",
+        "203.0.113.0/24",
+        "224.0.0.0/4",
+        "240.0.0.0/4"
+    ).mapNotNull { parseIpv4Cidr(it) }
+
     fun decide(
         policy: RoutingPolicyConfig?,
         host: String? = null,
@@ -53,8 +76,39 @@ object RoutingPolicyMatcher {
             RoutingRuleType.Domain -> host != null && host == ruleValue.normalizedHost()
             RoutingRuleType.DomainSuffix -> host != null && host.matchesDomainSuffix(ruleValue)
             RoutingRuleType.IpCidr -> ip != null && ipv4InCidr(ip, ruleValue)
-            RoutingRuleType.GeoSite,
-            RoutingRuleType.GeoIp -> false
+            RoutingRuleType.GeoSite -> false
+            RoutingRuleType.GeoIp -> ip != null && geoIpCidrs(ruleValue).any { ipv4InCidr(ip, it.value) }
+        }
+    }
+
+    fun domainRules(policy: RoutingPolicyConfig?): List<DomainRoutingRule> {
+        val normalized = policy?.normalized() ?: return emptyList()
+        return normalized.rules.mapNotNull { rule ->
+            when (rule.type) {
+                RoutingRuleType.Domain,
+                RoutingRuleType.DomainSuffix,
+                RoutingRuleType.GeoSite -> DomainRoutingRule(
+                    type = rule.type,
+                    value = rule.value.trim(),
+                    action = rule.action
+                )
+
+                RoutingRuleType.IpCidr,
+                RoutingRuleType.GeoIp -> null
+            }
+        }
+    }
+
+    fun geoIpCidrs(value: String): List<Ipv4Cidr> {
+        return when (value.normalizedRuleToken()) {
+            "private",
+            "geoip:private",
+            "lan",
+            "geoip:lan",
+            "local",
+            "geoip:local" -> privateIpv4Cidrs
+
+            else -> emptyList()
         }
     }
 
@@ -106,5 +160,9 @@ object RoutingPolicyMatcher {
             result = (result shl 8) or octet
         }
         return result
+    }
+
+    private fun String.normalizedRuleToken(): String {
+        return trim().lowercase()
     }
 }

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
@@ -1,0 +1,93 @@
+package org.olcbox.app.data.routing
+
+import org.olcbox.app.data.model.RoutingPolicyConfig
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleConfig
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
+
+enum class RoutingDecision {
+    Proxy,
+    Bypass
+}
+
+object RoutingPolicyMatcher {
+    fun decide(
+        policy: RoutingPolicyConfig?,
+        host: String? = null,
+        ip: String? = null
+    ): RoutingDecision {
+        val normalizedPolicy = policy?.normalized() ?: return RoutingDecision.Proxy
+        val normalizedHost = host.normalizedHost()
+        val ipValue = ip?.trim()?.takeIf { it.isNotEmpty() }
+        val matchedAction = normalizedPolicy.rules
+            .firstOrNull { rule -> rule.matches(normalizedHost, ipValue) }
+            ?.action
+
+        return when (matchedAction) {
+            RoutingRuleAction.Proxy -> RoutingDecision.Proxy
+            RoutingRuleAction.Bypass -> RoutingDecision.Bypass
+            null -> normalizedPolicy.defaultDecision()
+        }
+    }
+
+    private fun RoutingPolicyConfig.defaultDecision(): RoutingDecision {
+        return when (splitTunnel) {
+            RoutingSplitTunnelMode.FullTunnel,
+            RoutingSplitTunnelMode.BypassSelected -> RoutingDecision.Proxy
+            RoutingSplitTunnelMode.ProxySelected -> RoutingDecision.Bypass
+        }
+    }
+
+    private fun RoutingRuleConfig.matches(host: String?, ip: String?): Boolean {
+        val ruleValue = value.trim()
+        if (ruleValue.isBlank()) return false
+
+        return when (type) {
+            RoutingRuleType.Domain -> host != null && host == ruleValue.normalizedHost()
+            RoutingRuleType.DomainSuffix -> host != null && host.matchesDomainSuffix(ruleValue)
+            RoutingRuleType.IpCidr -> ip != null && ipv4InCidr(ip, ruleValue)
+            RoutingRuleType.GeoSite,
+            RoutingRuleType.GeoIp -> false
+        }
+    }
+
+    private fun String?.normalizedHost(): String? {
+        return this
+            ?.trim()
+            ?.removeSuffix(".")
+            ?.lowercase()
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun String.matchesDomainSuffix(ruleValue: String): Boolean {
+        val suffix = ruleValue.normalizedHost() ?: return false
+        return this == suffix || endsWith(".$suffix")
+    }
+
+    private fun ipv4InCidr(ip: String, cidr: String): Boolean {
+        val separator = cidr.indexOf('/')
+        if (separator <= 0 || separator == cidr.lastIndex) return false
+
+        val network = parseIpv4(cidr.substring(0, separator).trim()) ?: return false
+        val prefix = cidr.substring(separator + 1).trim().toIntOrNull() ?: return false
+        if (prefix !in 0..32) return false
+
+        val address = parseIpv4(ip) ?: return false
+        val mask = if (prefix == 0) 0 else (-1 shl (32 - prefix))
+        return (address and mask) == (network and mask)
+    }
+
+    private fun parseIpv4(value: String): Int? {
+        val parts = value.trim().split('.')
+        if (parts.size != 4) return null
+
+        var result = 0
+        for (part in parts) {
+            val octet = part.toIntOrNull() ?: return null
+            if (octet !in 0..255) return null
+            result = (result shl 8) or octet
+        }
+        return result
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlanner.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlanner.kt
@@ -9,6 +9,10 @@ data class RoutingPolicyRuntimePlan(
     val splitTunnel: RoutingSplitTunnelMode = RoutingSplitTunnelMode.FullTunnel,
     val proxyIpv4Cidrs: List<Ipv4Cidr> = emptyList(),
     val bypassIpv4Cidrs: List<Ipv4Cidr> = emptyList(),
+    val proxyDomainRules: List<DomainRoutingRule> = emptyList(),
+    val bypassDomainRules: List<DomainRoutingRule> = emptyList(),
+    val proxyDatCategories: List<String> = emptyList(),
+    val bypassDatCategories: List<String> = emptyList(),
     val domainRuleCount: Int = 0,
     val geoRuleCount: Int = 0,
     val datListCount: Int = 0,
@@ -24,6 +28,12 @@ data class RoutingPolicyRuntimePlan(
     val hasResolverRules: Boolean
         get() = domainRuleCount > 0 || geoRuleCount > 0 || datListCount > 0
 
+    val hasMapDnsRules: Boolean
+        get() = proxyDomainRules.isNotEmpty() ||
+            bypassDomainRules.isNotEmpty() ||
+            proxyDatCategories.isNotEmpty() ||
+            bypassDatCategories.isNotEmpty()
+
     fun summary(): String {
         if (!hasPolicy) return "Routing policy: none"
 
@@ -32,8 +42,9 @@ data class RoutingPolicyRuntimePlan(
             proxyIpv4Cidrs.size.takeIf { it > 0 }?.let { "proxy CIDR=$it" },
             bypassIpv4Cidrs.size.takeIf { it > 0 }?.let { "bypass CIDR=$it" },
             domainRuleCount.takeIf { it > 0 }?.let { "domain=$it" },
-            geoRuleCount.takeIf { it > 0 }?.let { "geo/dat=$it" },
+            geoRuleCount.takeIf { it > 0 }?.let { "geo=$it" },
             datListCount.takeIf { it > 0 }?.let { "dat lists=$it" },
+            datCategoryCount.takeIf { it > 0 }?.let { "dat categories=$it" },
             unsupportedRuleCount.takeIf { it > 0 }?.let { "unsupported=$it" }
         )
 
@@ -52,6 +63,8 @@ object RoutingPolicyPlanner {
 
         val proxyCidrs = mutableListOf<Ipv4Cidr>()
         val bypassCidrs = mutableListOf<Ipv4Cidr>()
+        val proxyDomainRules = mutableListOf<DomainRoutingRule>()
+        val bypassDomainRules = mutableListOf<DomainRoutingRule>()
         var domainRules = 0
         var geoRules = 0
         var unsupportedRules = 0
@@ -59,10 +72,52 @@ object RoutingPolicyPlanner {
         normalized.rules.forEach { rule ->
             when (rule.type) {
                 RoutingRuleType.Domain,
-                RoutingRuleType.DomainSuffix -> domainRules += 1
+                RoutingRuleType.DomainSuffix -> {
+                    domainRules += 1
+                    when (rule.action) {
+                        RoutingRuleAction.Proxy -> proxyDomainRules += DomainRoutingRule(
+                            type = rule.type,
+                            value = rule.value,
+                            action = rule.action
+                        )
 
-                RoutingRuleType.GeoSite,
-                RoutingRuleType.GeoIp -> geoRules += 1
+                        RoutingRuleAction.Bypass -> bypassDomainRules += DomainRoutingRule(
+                            type = rule.type,
+                            value = rule.value,
+                            action = rule.action
+                        )
+                    }
+                }
+
+                RoutingRuleType.GeoSite -> {
+                    geoRules += 1
+                    when (rule.action) {
+                        RoutingRuleAction.Proxy -> proxyDomainRules += DomainRoutingRule(
+                            type = rule.type,
+                            value = rule.value,
+                            action = rule.action
+                        )
+
+                        RoutingRuleAction.Bypass -> bypassDomainRules += DomainRoutingRule(
+                            type = rule.type,
+                            value = rule.value,
+                            action = rule.action
+                        )
+                    }
+                }
+
+                RoutingRuleType.GeoIp -> {
+                    geoRules += 1
+                    val geoCidrs = RoutingPolicyMatcher.geoIpCidrs(rule.value)
+                    if (geoCidrs.isEmpty()) {
+                        unsupportedRules += 1
+                    } else {
+                        when (rule.action) {
+                            RoutingRuleAction.Proxy -> proxyCidrs += geoCidrs
+                            RoutingRuleAction.Bypass -> bypassCidrs += geoCidrs
+                        }
+                    }
+                }
 
                 RoutingRuleType.IpCidr -> {
                     val cidr = RoutingPolicyMatcher.parseIpv4Cidr(rule.value)
@@ -78,12 +133,24 @@ object RoutingPolicyPlanner {
             }
         }
 
-        val datCategories = normalized.datLists.sumOf { it.categories.size }
+        val proxyDatCategories = normalized.datLists
+            .filter { it.action == RoutingRuleAction.Proxy }
+            .flatMap { it.categories }
+            .distinct()
+        val bypassDatCategories = normalized.datLists
+            .filter { it.action == RoutingRuleAction.Bypass }
+            .flatMap { it.categories }
+            .distinct()
+        val datCategories = proxyDatCategories.size + bypassDatCategories.size
 
         return RoutingPolicyRuntimePlan(
             splitTunnel = normalized.splitTunnel,
             proxyIpv4Cidrs = proxyCidrs.distinctBy { it.value },
             bypassIpv4Cidrs = bypassCidrs.distinctBy { it.value },
+            proxyDomainRules = proxyDomainRules.distinctBy { "${it.type}|${it.value}|${it.action}" },
+            bypassDomainRules = bypassDomainRules.distinctBy { "${it.type}|${it.value}|${it.action}" },
+            proxyDatCategories = proxyDatCategories,
+            bypassDatCategories = bypassDatCategories,
             domainRuleCount = domainRules,
             geoRuleCount = geoRules,
             datListCount = normalized.datLists.size,

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlanner.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlanner.kt
@@ -158,12 +158,12 @@ object RoutingPolicyPlanner {
             unsupportedRuleCount = unsupportedRules
         )
     }
+}
 
-    private fun RoutingSplitTunnelMode.serializedName(): String {
-        return when (this) {
-            RoutingSplitTunnelMode.FullTunnel -> "full_tunnel"
-            RoutingSplitTunnelMode.ProxySelected -> "proxy_selected"
-            RoutingSplitTunnelMode.BypassSelected -> "bypass_selected"
-        }
+private fun RoutingSplitTunnelMode.serializedName(): String {
+    return when (this) {
+        RoutingSplitTunnelMode.FullTunnel -> "full_tunnel"
+        RoutingSplitTunnelMode.ProxySelected -> "proxy_selected"
+        RoutingSplitTunnelMode.BypassSelected -> "bypass_selected"
     }
 }

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlanner.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlanner.kt
@@ -1,0 +1,102 @@
+package org.olcbox.app.data.routing
+
+import org.olcbox.app.data.model.RoutingPolicyConfig
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
+
+data class RoutingPolicyRuntimePlan(
+    val splitTunnel: RoutingSplitTunnelMode = RoutingSplitTunnelMode.FullTunnel,
+    val proxyIpv4Cidrs: List<Ipv4Cidr> = emptyList(),
+    val bypassIpv4Cidrs: List<Ipv4Cidr> = emptyList(),
+    val domainRuleCount: Int = 0,
+    val geoRuleCount: Int = 0,
+    val datListCount: Int = 0,
+    val datCategoryCount: Int = 0,
+    val unsupportedRuleCount: Int = 0
+) {
+    val hasPolicy: Boolean
+        get() = this != Empty
+
+    val hasRouteLevelRules: Boolean
+        get() = proxyIpv4Cidrs.isNotEmpty() || bypassIpv4Cidrs.isNotEmpty()
+
+    val hasResolverRules: Boolean
+        get() = domainRuleCount > 0 || geoRuleCount > 0 || datListCount > 0
+
+    fun summary(): String {
+        if (!hasPolicy) return "Routing policy: none"
+
+        val parts = listOfNotNull(
+            "mode=${splitTunnel.serializedName()}",
+            proxyIpv4Cidrs.size.takeIf { it > 0 }?.let { "proxy CIDR=$it" },
+            bypassIpv4Cidrs.size.takeIf { it > 0 }?.let { "bypass CIDR=$it" },
+            domainRuleCount.takeIf { it > 0 }?.let { "domain=$it" },
+            geoRuleCount.takeIf { it > 0 }?.let { "geo/dat=$it" },
+            datListCount.takeIf { it > 0 }?.let { "dat lists=$it" },
+            unsupportedRuleCount.takeIf { it > 0 }?.let { "unsupported=$it" }
+        )
+
+        return "Routing policy: ${parts.joinToString(", ")}"
+    }
+
+    companion object {
+        val Empty = RoutingPolicyRuntimePlan()
+    }
+}
+
+object RoutingPolicyPlanner {
+    fun plan(policy: RoutingPolicyConfig?): RoutingPolicyRuntimePlan {
+        val normalized = policy?.normalized()?.takeUnless { it.isEmpty() }
+            ?: return RoutingPolicyRuntimePlan.Empty
+
+        val proxyCidrs = mutableListOf<Ipv4Cidr>()
+        val bypassCidrs = mutableListOf<Ipv4Cidr>()
+        var domainRules = 0
+        var geoRules = 0
+        var unsupportedRules = 0
+
+        normalized.rules.forEach { rule ->
+            when (rule.type) {
+                RoutingRuleType.Domain,
+                RoutingRuleType.DomainSuffix -> domainRules += 1
+
+                RoutingRuleType.GeoSite,
+                RoutingRuleType.GeoIp -> geoRules += 1
+
+                RoutingRuleType.IpCidr -> {
+                    val cidr = RoutingPolicyMatcher.parseIpv4Cidr(rule.value)
+                    if (cidr == null) {
+                        unsupportedRules += 1
+                    } else {
+                        when (rule.action) {
+                            RoutingRuleAction.Proxy -> proxyCidrs += cidr
+                            RoutingRuleAction.Bypass -> bypassCidrs += cidr
+                        }
+                    }
+                }
+            }
+        }
+
+        val datCategories = normalized.datLists.sumOf { it.categories.size }
+
+        return RoutingPolicyRuntimePlan(
+            splitTunnel = normalized.splitTunnel,
+            proxyIpv4Cidrs = proxyCidrs.distinctBy { it.value },
+            bypassIpv4Cidrs = bypassCidrs.distinctBy { it.value },
+            domainRuleCount = domainRules,
+            geoRuleCount = geoRules,
+            datListCount = normalized.datLists.size,
+            datCategoryCount = datCategories,
+            unsupportedRuleCount = unsupportedRules
+        )
+    }
+
+    private fun RoutingSplitTunnelMode.serializedName(): String {
+        return when (this) {
+            RoutingSplitTunnelMode.FullTunnel -> "full_tunnel"
+            RoutingSplitTunnelMode.ProxySelected -> "proxy_selected"
+            RoutingSplitTunnelMode.BypassSelected -> "bypass_selected"
+        }
+    }
+}

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreenModel.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreenModel.kt
@@ -15,6 +15,7 @@ import org.olcbox.app.data.exporter.LogExporter
 import org.olcbox.app.data.importer.ConfigImporter
 import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.repository.LocationsRepository
+import org.olcbox.app.data.routing.RoutingPolicyPlanner
 import org.olcbox.app.ui.features.locations.LocationItem
 import org.olcbox.app.vpn.VpnManager
 import org.olcbox.app.vpn.VpnStatus
@@ -95,7 +96,10 @@ class HomeScreenViewModel(
             fullName = normalized.displayName(),
             config = normalized,
             subscriptionUrl = active.subscriptionUrl,
-            metadata = active.metadata
+            metadata = active.metadata,
+            routingSummary = RoutingPolicyPlanner.plan(active.routing)
+                .takeIf { it.hasPolicy }
+                ?.summary()
         )
 
         _state.update {

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/LocationViewModel.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/LocationViewModel.kt
@@ -19,13 +19,15 @@ import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.model.LocationMetadata
 import org.olcbox.app.data.model.SubscriptionMetadata
 import org.olcbox.app.data.repository.LocationsRepository
+import org.olcbox.app.data.routing.RoutingPolicyPlanner
 
 data class LocationItem(
     val storageId: String,
     val fullName: String,
     val config: LocationConfig? = null,
     val subscriptionUrl: String? = null,
-    val metadata: LocationMetadata? = null
+    val metadata: LocationMetadata? = null,
+    val routingSummary: String? = null
 )
 
 sealed class PingsState {
@@ -124,7 +126,10 @@ class LocationViewModel(
                     fullName = normalized.displayName(),
                     config = normalized,
                     subscriptionUrl = entry.subscriptionUrl,
-                    metadata = entry.metadata
+                    metadata = entry.metadata,
+                    routingSummary = RoutingPolicyPlanner.plan(entry.routing)
+                        .takeIf { it.hasPolicy }
+                        ?.summary()
                 )
             }
 

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/components/LocationRow.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/locations/components/LocationRow.kt
@@ -180,6 +180,7 @@ private fun locationSubtitle(location: LocationItem): String {
     return listOfNotNull(
         providerName,
         transportName,
+        location.routingSummary,
         metadata?.comment?.takeIf { it.isNotBlank() },
         metadata?.ip?.takeIf { it.isNotBlank() }?.let { "IP $it" },
         quotaText(metadata?.used, metadata?.available)

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
@@ -11,6 +11,9 @@ import org.olcbox.app.data.identity.DeviceIdentityProvider
 import org.olcbox.app.data.model.LocationBundleV4
 import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.model.LocationEntry
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
 import org.olcbox.app.data.share.ConfigShareService
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -367,6 +370,87 @@ class LocationsRepositoryImplTest {
         assertNotNull(imported)
         assertEquals(LocationConfig.TRANSPORT_VP8CHANNEL, imported.locations[0].location.transport)
         assertEquals(LocationConfig.TRANSPORT_DATACHANNEL, imported.locations[1].location.transport)
+    }
+
+    @Test
+    fun importsExportsAndPreservesSubscriptionRoutingPolicy() = runTest {
+        val source = FakeLocationsDataSource()
+        val input = """
+            {
+              "version": 5,
+              "active_location_id": "ru",
+              "locations": [
+                {
+                  "storage_id": "ru",
+                  "name": "RU",
+                  "endpoint": {
+                    "room_id": "room-ru",
+                    "key": "${"e".repeat(64)}"
+                  },
+                  "auth_provider": "wbstream",
+                  "transport": {
+                    "type": "vp8channel"
+                  },
+                  "routing": {
+                    "split_tunnel": "bypass_selected",
+                    "dat_lists": [
+                      {
+                        "name": "ru-sites",
+                        "url": "https://example.test/geosite.dat",
+                        "categories": ["geosite:ru", " geosite:vk ", "geosite:ru"],
+                        "action": "bypass"
+                      }
+                    ],
+                    "rules": [
+                      {
+                        "type": "domain_suffix",
+                        "value": "youtube.com",
+                        "action": "proxy"
+                      },
+                      {
+                        "type": "ip_cidr",
+                        "value": "10.0.0.0/8",
+                        "action": "bypass"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val repository = LocationsRepositoryImpl(source)
+        repository.importText(input)
+
+        val imported = source.stored
+        assertNotNull(imported)
+        val routing = imported.locations.single().routing
+        assertNotNull(routing)
+        assertEquals(RoutingSplitTunnelMode.BypassSelected, routing.splitTunnel)
+        assertEquals(listOf("geosite:ru", "geosite:vk"), routing.datLists.single().categories)
+        assertEquals(RoutingRuleAction.Bypass, routing.datLists.single().action)
+        assertEquals(RoutingRuleType.DomainSuffix, routing.rules[0].type)
+        assertEquals("youtube.com", routing.rules[0].value)
+        assertEquals(RoutingRuleType.IpCidr, routing.rules[1].type)
+
+        val exported = repository.exportBundle()
+        assertTrue("\"routing\"" in exported)
+        assertTrue("\"dat_lists\"" in exported)
+
+        repository.saveLocation(
+            storageId = "ru",
+            location = LocationConfig(
+                name = "RU updated",
+                id = "room-ru",
+                key = "f".repeat(64),
+                bypassProvider = LocationConfig.PROVIDER_WB_STREAM
+            )
+        )
+
+        val updatedRouting = source.stored?.locations?.single()?.routing
+        assertNotNull(updatedRouting)
+        assertEquals(RoutingSplitTunnelMode.BypassSelected, updatedRouting.splitTunnel)
+        assertEquals("https://example.test/geosite.dat", updatedRouting.datLists.single().url)
     }
 
     @Test

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
@@ -92,4 +92,22 @@ class RoutingPolicyMatcherTest {
         assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "youtube.com"))
         assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "10.0.0.1"))
     }
+
+    @Test
+    fun matchesPrivateGeoIpRulesAsIpv4Cidrs() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.FullTunnel,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.GeoIp,
+                    value = "geoip:private",
+                    action = RoutingRuleAction.Bypass
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Bypass, RoutingPolicyMatcher.decide(policy, ip = "10.0.0.1"))
+        assertEquals(RoutingDecision.Bypass, RoutingPolicyMatcher.decide(policy, ip = "192.168.1.2"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "8.8.8.8"))
+    }
 }

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
@@ -1,0 +1,95 @@
+package org.olcbox.app.data.routing
+
+import org.olcbox.app.data.model.RoutingPolicyConfig
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleConfig
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoutingPolicyMatcherTest {
+    @Test
+    fun defaultsToProxyForFullTunnelAndBypassSelectedModes() {
+        assertEquals(
+            RoutingDecision.Proxy,
+            RoutingPolicyMatcher.decide(RoutingPolicyConfig(splitTunnel = RoutingSplitTunnelMode.FullTunnel))
+        )
+        assertEquals(
+            RoutingDecision.Proxy,
+            RoutingPolicyMatcher.decide(RoutingPolicyConfig(splitTunnel = RoutingSplitTunnelMode.BypassSelected))
+        )
+    }
+
+    @Test
+    fun defaultsToBypassForProxySelectedMode() {
+        assertEquals(
+            RoutingDecision.Bypass,
+            RoutingPolicyMatcher.decide(RoutingPolicyConfig(splitTunnel = RoutingSplitTunnelMode.ProxySelected))
+        )
+    }
+
+    @Test
+    fun matchesDomainAndDomainSuffixRules() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.ProxySelected,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.Domain,
+                    value = "api.example.com",
+                    action = RoutingRuleAction.Proxy
+                ),
+                RoutingRuleConfig(
+                    type = RoutingRuleType.DomainSuffix,
+                    value = "youtube.com",
+                    action = RoutingRuleAction.Proxy
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "API.EXAMPLE.COM."))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "www.youtube.com"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "youtube.com"))
+        assertEquals(RoutingDecision.Bypass, RoutingPolicyMatcher.decide(policy, host = "notyoutube.com"))
+    }
+
+    @Test
+    fun matchesIpv4CidrRules() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.FullTunnel,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.IpCidr,
+                    value = "10.32.0.0/12",
+                    action = RoutingRuleAction.Bypass
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Bypass, RoutingPolicyMatcher.decide(policy, ip = "10.47.255.1"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "10.48.0.1"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "not-an-ip"))
+    }
+
+    @Test
+    fun leavesGeoRulesForDatResolver() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.FullTunnel,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.GeoSite,
+                    value = "geosite:youtube",
+                    action = RoutingRuleAction.Bypass
+                ),
+                RoutingRuleConfig(
+                    type = RoutingRuleType.GeoIp,
+                    value = "geoip:private",
+                    action = RoutingRuleAction.Bypass
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "youtube.com"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "10.0.0.1"))
+    }
+}

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
@@ -83,7 +83,7 @@ class RoutingPolicyMatcherTest {
                 ),
                 RoutingRuleConfig(
                     type = RoutingRuleType.GeoIp,
-                    value = "geoip:private",
+                    value = "geoip:ru",
                     action = RoutingRuleAction.Bypass
                 )
             )

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlannerTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlannerTest.kt
@@ -54,6 +54,11 @@ class RoutingPolicyPlannerTest {
                         action = RoutingRuleAction.Bypass
                     ),
                     RoutingRuleConfig(
+                        type = RoutingRuleType.GeoIp,
+                        value = "geoip:private",
+                        action = RoutingRuleAction.Bypass
+                    ),
+                    RoutingRuleConfig(
                         type = RoutingRuleType.IpCidr,
                         value = "not-a-cidr",
                         action = RoutingRuleAction.Bypass
@@ -65,10 +70,33 @@ class RoutingPolicyPlannerTest {
         assertTrue(plan.hasPolicy)
         assertTrue(plan.hasRouteLevelRules)
         assertTrue(plan.hasResolverRules)
+        assertTrue(plan.hasMapDnsRules)
         assertEquals(listOf("203.0.113.0/24"), plan.proxyIpv4Cidrs.map { it.value })
-        assertEquals(listOf("10.0.0.0/8"), plan.bypassIpv4Cidrs.map { it.value })
+        assertEquals(
+            listOf(
+                "10.0.0.0/8",
+                "0.0.0.0/8",
+                "100.64.0.0/10",
+                "127.0.0.0/8",
+                "169.254.0.0/16",
+                "172.16.0.0/12",
+                "192.0.0.0/24",
+                "192.0.2.0/24",
+                "192.168.0.0/16",
+                "198.18.0.0/15",
+                "198.51.100.0/24",
+                "203.0.113.0/24",
+                "224.0.0.0/4",
+                "240.0.0.0/4"
+            ),
+            plan.bypassIpv4Cidrs.map { it.value }
+        )
+        assertEquals(listOf("youtube.com"), plan.proxyDomainRules.map { it.value })
+        assertEquals(listOf("geosite:vk"), plan.bypassDomainRules.map { it.value })
+        assertEquals(listOf("geosite:ru", "geosite:youtube"), plan.proxyDatCategories)
+        assertEquals(emptyList(), plan.bypassDatCategories)
         assertEquals(1, plan.domainRuleCount)
-        assertEquals(1, plan.geoRuleCount)
+        assertEquals(2, plan.geoRuleCount)
         assertEquals(1, plan.datListCount)
         assertEquals(2, plan.datCategoryCount)
         assertEquals(1, plan.unsupportedRuleCount)

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlannerTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyPlannerTest.kt
@@ -1,0 +1,76 @@
+package org.olcbox.app.data.routing
+
+import org.olcbox.app.data.model.RoutingDatListConfig
+import org.olcbox.app.data.model.RoutingPolicyConfig
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleConfig
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RoutingPolicyPlannerTest {
+    @Test
+    fun emptyPolicyProducesEmptyPlan() {
+        val plan = RoutingPolicyPlanner.plan(null)
+
+        assertFalse(plan.hasPolicy)
+        assertEquals("Routing policy: none", plan.summary())
+    }
+
+    @Test
+    fun separatesRouteLevelAndResolverRules() {
+        val plan = RoutingPolicyPlanner.plan(
+            RoutingPolicyConfig(
+                splitTunnel = RoutingSplitTunnelMode.BypassSelected,
+                datLists = listOf(
+                    RoutingDatListConfig(
+                        name = "geosite",
+                        url = "https://example.test/geosite.dat",
+                        categories = listOf("geosite:ru", "geosite:youtube")
+                    )
+                ),
+                rules = listOf(
+                    RoutingRuleConfig(
+                        type = RoutingRuleType.IpCidr,
+                        value = "10.0.0.0/8",
+                        action = RoutingRuleAction.Bypass
+                    ),
+                    RoutingRuleConfig(
+                        type = RoutingRuleType.IpCidr,
+                        value = "203.0.113.0/24",
+                        action = RoutingRuleAction.Proxy
+                    ),
+                    RoutingRuleConfig(
+                        type = RoutingRuleType.DomainSuffix,
+                        value = "youtube.com",
+                        action = RoutingRuleAction.Proxy
+                    ),
+                    RoutingRuleConfig(
+                        type = RoutingRuleType.GeoSite,
+                        value = "geosite:vk",
+                        action = RoutingRuleAction.Bypass
+                    ),
+                    RoutingRuleConfig(
+                        type = RoutingRuleType.IpCidr,
+                        value = "not-a-cidr",
+                        action = RoutingRuleAction.Bypass
+                    )
+                )
+            )
+        )
+
+        assertTrue(plan.hasPolicy)
+        assertTrue(plan.hasRouteLevelRules)
+        assertTrue(plan.hasResolverRules)
+        assertEquals(listOf("203.0.113.0/24"), plan.proxyIpv4Cidrs.map { it.value })
+        assertEquals(listOf("10.0.0.0/8"), plan.bypassIpv4Cidrs.map { it.value })
+        assertEquals(1, plan.domainRuleCount)
+        assertEquals(1, plan.geoRuleCount)
+        assertEquals(1, plan.datListCount)
+        assertEquals(2, plan.datCategoryCount)
+        assertEquals(1, plan.unsupportedRuleCount)
+    }
+}

--- a/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
+++ b/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
@@ -3,14 +3,17 @@ package org.olcbox.app.vpn
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -48,13 +51,27 @@ class IosVpnManager(
     private var operationJob: Job? = null
     private var generation = 0L
 
+    // Auto-reconnect state. The iOS transport (Go/WebRTC) does not restart ICE on
+    // its own, so when the underlying connection drops (network migration, the app
+    // being briefly suspended, TURN failures) we detect it and rebuild the SOCKS
+    // session ourselves — mirroring what OlcboxVpnService does on Android.
+    private var desiredConnected = false
+    private var watchdogJob: Job? = null
+    private var reconnectJob: Job? = null
+    private var reconnectAttempt = 0
+    private val timeSource = TimeSource.Monotonic
+    private var lastReadyMark: TimeSource.Monotonic.ValueTimeMark? = null
+
     init {
         olcRtcBridge.setLogWriter(object : IosLogWriter {
             override fun writeLog(message: String) {
                 message
                     .trim()
                     .takeIf { it.isNotBlank() }
-                    ?.let { addLog("rtc: $it") }
+                    ?.let {
+                        addLog("rtc: $it")
+                        handleRtcLine(it)
+                    }
             }
         })
     }
@@ -62,6 +79,9 @@ class IosVpnManager(
     override fun needsPermission(): Boolean = false
 
     override fun startVpn() {
+        desiredConnected = true
+        reconnectAttempt = 0
+        reconnectJob?.cancel()
         val requestedGeneration = ++generation
         operationJob = scope.launch {
             mutex.withLock {
@@ -85,6 +105,9 @@ class IosVpnManager(
     }
 
     override fun stopVpn() {
+        desiredConnected = false
+        watchdogJob?.cancel()
+        reconnectJob?.cancel()
         generation++
         operationJob = scope.launch {
             mutex.withLock {
@@ -124,6 +147,9 @@ class IosVpnManager(
     }
 
     fun close() {
+        desiredConnected = false
+        watchdogJob?.cancel()
+        reconnectJob?.cancel()
         generation++
         runCatching { olcRtcBridge.setLogWriter(null) }
         runCatching { olcRtcBridge.stop() }
@@ -160,6 +186,9 @@ class IosVpnManager(
         if (result.success) {
             setStatus(VpnStatus.Connected)
             addLog("iOS SOCKS ready on 127.0.0.1:${socksSettings.port}")
+            reconnectAttempt = 0
+            lastReadyMark = timeSource.markNow()
+            startWatchdog()
         } else {
             val message = result.message ?: "olcRTC start failed"
             setStatus(VpnStatus.Error(message))
@@ -196,6 +225,106 @@ class IosVpnManager(
         }.getOrElse {
             IosBridgeResult(success = false, message = it.message)
         }
+    }
+
+    /**
+     * Parses olcRTC log lines to detect transport health. The native layer never
+     * performs an ICE restart, so a dropped connection stays dead until we rebuild
+     * it. We treat "connected/listening" markers as healthy and "failed/closed/
+     * broken pipe" markers as a lost transport that must be reconnected.
+     */
+    private fun handleRtcLine(line: String) {
+        if (!desiredConnected) return
+        val lower = line.lowercase()
+
+        if (lower.contains("socks5 server listening") ||
+            lower.contains("ice connection state changed: connected") ||
+            lower.contains("peer connection state changed: connected")
+        ) {
+            reconnectAttempt = 0
+            lastReadyMark = timeSource.markNow()
+            return
+        }
+
+        val transportLost = lower.contains("ice connection state changed: failed") ||
+            lower.contains("peer connection state changed: failed") ||
+            lower.contains("ice connection state changed: closed") ||
+            lower.contains("peer connection state changed: closed") ||
+            lower.contains("read/write on closed pipe") ||
+            lower.contains("use of closed network connection")
+
+        if (transportLost) {
+            // Ignore teardown noise that immediately follows a fresh (re)connect.
+            val recentlyReady = lastReadyMark
+                ?.elapsedNow()
+                ?.inWholeMilliseconds
+                ?.let { it < POST_CONNECT_GRACE_MS }
+                ?: false
+            if (recentlyReady) return
+            scheduleReconnect("RTC transport lost")
+        }
+    }
+
+    /**
+     * Periodically verifies the SOCKS transport is still up while the user wants to
+     * stay connected, catching silent deaths that produce no log marker.
+     */
+    private fun startWatchdog() {
+        watchdogJob?.cancel()
+        watchdogJob = scope.launch {
+            while (isActive && desiredConnected) {
+                delay(WATCHDOG_INTERVAL_MS)
+                if (!desiredConnected) break
+                val stalled = _status.value is VpnStatus.Connected &&
+                    reconnectJob?.isActive != true &&
+                    !olcRtcBridge.isRunning()
+                if (stalled) {
+                    addLog("Watchdog: iOS SOCKS transport is down")
+                    scheduleReconnect("transport stopped")
+                }
+            }
+        }
+    }
+
+    private fun scheduleReconnect(reason: String) {
+        if (!desiredConnected) return
+        if (reconnectJob?.isActive == true) return
+        val status = _status.value
+        if (status !is VpnStatus.Connected && status !is VpnStatus.Reconnecting) return
+
+        reconnectJob = scope.launch {
+            setStatus(VpnStatus.Reconnecting)
+            addLog("Auto-reconnect requested ($reason)")
+
+            // Keep retrying with exponential backoff until we reconnect or the user
+            // turns the connection off. A single failed attempt (e.g. no network yet)
+            // must not give up — that is what left the transport dead before.
+            while (desiredConnected && isActive) {
+                val delayMs = nextReconnectDelay()
+                addLog("Reconnecting iOS SOCKS in ${delayMs / 1000}s")
+                delay(delayMs)
+                if (!desiredConnected) return@launch
+
+                val requestedGeneration = ++generation
+                val reconnected = mutex.withLock {
+                    if (requestedGeneration != generation || !desiredConnected) return@withLock false
+                    stopOlcRtc()
+                    startOlcRtc(requestedGeneration, isRestart = true)
+                    _status.value is VpnStatus.Connected
+                }
+
+                if (reconnected || !desiredConnected) return@launch
+                // startOlcRtc reports failure via Error status; keep the user-facing
+                // state as Reconnecting so the retry loop stays coherent.
+                if (_status.value !is VpnStatus.Reconnecting) setStatus(VpnStatus.Reconnecting)
+            }
+        }
+    }
+
+    private fun nextReconnectDelay(): Long {
+        val multiplier = 1L shl reconnectAttempt.coerceAtMost(MAX_RECONNECT_BACKOFF_POWER)
+        reconnectAttempt++
+        return (RECONNECT_BASE_DELAY_MS * multiplier).coerceAtMost(RECONNECT_MAX_DELAY_MS)
     }
 
     private fun setStatus(status: VpnStatus) {
@@ -276,6 +405,11 @@ class IosVpnManager(
         const val MAX_LOG_LINES = 500
         const val CHECK_TIMEOUT_MS = 8_000L
         const val HTTP_PING_URL = "https://www.google.com/generate_204"
+        const val WATCHDOG_INTERVAL_MS = 10_000L
+        const val RECONNECT_BASE_DELAY_MS = 2_000L
+        const val RECONNECT_MAX_DELAY_MS = 30_000L
+        const val MAX_RECONNECT_BACKOFF_POWER = 3
+        const val POST_CONNECT_GRACE_MS = 4_000L
         const val CREDENTIAL_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"
     }
 }

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/update/JvmUpdateInstaller.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/update/JvmUpdateInstaller.kt
@@ -2,9 +2,13 @@ package org.olcbox.app.update
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.olcbox.app.data.datasource.withProxyAuthentication
+import org.olcbox.app.data.repository.SubscriptionFetchProxy
 import org.olcbox.app.desktop.DesktopPaths
 import java.awt.Desktop
+import java.net.InetSocketAddress
 import java.net.HttpURLConnection
+import java.net.Proxy
 import java.net.URI
 import java.net.URL
 import java.nio.file.Files
@@ -12,13 +16,17 @@ import java.nio.file.Path
 import kotlin.io.path.outputStream
 
 class JvmUpdateInstaller(
-    private val directory: Path = DesktopPaths.appDataDir().resolve("updates")
+    private val directory: Path = DesktopPaths.appDataDir().resolve("updates"),
+    private val proxyProvider: () -> SubscriptionFetchProxy? = { null }
 ) {
     suspend fun downloadAndOpen(
         asset: AppUpdateAsset,
         onProgress: (Float) -> Unit = {}
     ): Result<String> = runCatching {
-        val file = download(asset, onProgress)
+        val proxy = proxyProvider()
+        val file = withProxyAuthentication(proxy) {
+            download(asset, onProgress, proxy)
+        }
         val desktop = if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null
         when {
             desktop?.isSupported(Desktop.Action.OPEN) == true -> desktop.open(file.toFile())
@@ -30,11 +38,18 @@ class JvmUpdateInstaller(
 
     private suspend fun download(
         asset: AppUpdateAsset,
-        onProgress: (Float) -> Unit
+        onProgress: (Float) -> Unit,
+        proxy: SubscriptionFetchProxy?
     ): Path = withContext(Dispatchers.IO) {
         Files.createDirectories(directory)
         val target = directory.resolve(asset.name.substringAfterLast('/').ifBlank { "olcbox-update" })
-        val connection = URL(asset.downloadUrl).openConnection() as HttpURLConnection
+        val connection = if (proxy == null) {
+            URL(asset.downloadUrl).openConnection()
+        } else {
+            URL(asset.downloadUrl).openConnection(
+                Proxy(Proxy.Type.SOCKS, InetSocketAddress(proxy.host, proxy.port))
+            )
+        } as HttpURLConnection
         connection.connectTimeout = 10_000
         connection.readTimeout = 60_000
         val total = connection.contentLengthLong.takeIf { it > 0L } ?: asset.sizeBytes ?: -1L

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -292,8 +292,11 @@ class DesktopVpnManager private constructor(
         if (!routingPlan.hasPolicy) return
 
         addLog(routingPlan.summary())
-        if (routingPlan.hasResolverRules) {
-            addLog("Routing policy has domain/.dat rules; desktop TUN needs DNS resolver wiring before those can be enforced")
+        if (routingPlan.hasMapDnsRules) {
+            addLog("Routing policy mapdns is enabled for domain/geosite/.dat hostname matching in TUN modes")
+            if (routingPlan.bypassDomainRules.isNotEmpty() || routingPlan.bypassDatCategories.isNotEmpty()) {
+                addLog("Routing policy domain bypass rules need native direct-route support; CIDR bypass rules are enforced in Linux TUN")
+            }
         }
         if (routingPlan.proxyIpv4Cidrs.isNotEmpty()) {
             addLog("Routing policy has ${routingPlan.proxyIpv4Cidrs.size} proxy CIDR rule(s); current desktop modes keep proxy routes on the default path")

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.olcbox.app.data.model.LocationConfig
+import org.olcbox.app.data.routing.RoutingPolicyPlanner
+import org.olcbox.app.data.routing.RoutingPolicyRuntimePlan
 import org.olcbox.app.data.repository.LocationsRepository
 import org.olcbox.app.data.repository.SubscriptionFetchProxy
 import org.olcbox.app.desktop.DesktopOs
@@ -186,6 +188,7 @@ class DesktopVpnManager private constructor(
 
         val active = locationsRepository.getActiveLocation()
         val location = active?.location?.normalized()
+        val routingPlan = RoutingPolicyPlanner.plan(active?.routing)
 
         if (location == null || !location.isComplete()) {
             setStatus(VpnStatus.Error("No active location"))
@@ -198,6 +201,7 @@ class DesktopVpnManager private constructor(
             val startupFailure = CompletableDeferred<String>()
             val desktopMode = DesktopMode.current()
             val socksSettings = _socksProxySettings.value.normalized()
+            logRoutingPlan(routingPlan, desktopMode)
 
             if (desktopMode == DesktopMode.WindowsTun) {
                 windowsTunController.ensureAdministratorOrRequestRestart()
@@ -226,7 +230,7 @@ class DesktopVpnManager private constructor(
             }
 
             when (desktopMode) {
-                DesktopMode.LinuxTun -> startLinuxTun(socksSettings.port, requestGeneration)
+                DesktopMode.LinuxTun -> startLinuxTun(socksSettings.port, routingPlan, requestGeneration)
                 DesktopMode.WindowsTun -> startWindowsTun(socksSettings.port, requestGeneration)
                 DesktopMode.SystemProxy -> startSystemProxy(socksSettings, requestGeneration)
             }
@@ -265,15 +269,38 @@ class DesktopVpnManager private constructor(
         }
     }
 
-    private suspend fun startLinuxTun(socksPort: Int, requestGeneration: Long) {
+    private suspend fun startLinuxTun(
+        socksPort: Int,
+        routingPlan: RoutingPolicyRuntimePlan,
+        requestGeneration: Long
+    ) {
         val hevBinary = DesktopNativeAssets.resolveHevSocks5TunnelBinary()
-        tunProcess = linuxTunController.start(hevBinary, socksPort)
+        tunProcess = linuxTunController.start(
+            hevBinary = hevBinary,
+            socksPort = socksPort,
+            bypassCidrs = routingPlan.bypassIpv4Cidrs
+        )
 
         if (requestGeneration != generation) {
             throw CancellationException("Desktop start superseded")
         }
 
         startTunLogReader(tunProcess ?: error("hev-socks5-tunnel process is missing"))
+    }
+
+    private fun logRoutingPlan(routingPlan: RoutingPolicyRuntimePlan, desktopMode: DesktopMode) {
+        if (!routingPlan.hasPolicy) return
+
+        addLog(routingPlan.summary())
+        if (routingPlan.hasResolverRules) {
+            addLog("Routing policy has domain/.dat rules; desktop TUN needs DNS resolver wiring before those can be enforced")
+        }
+        if (routingPlan.proxyIpv4Cidrs.isNotEmpty()) {
+            addLog("Routing policy has ${routingPlan.proxyIpv4Cidrs.size} proxy CIDR rule(s); current desktop modes keep proxy routes on the default path")
+        }
+        if (routingPlan.bypassIpv4Cidrs.isNotEmpty() && desktopMode != DesktopMode.LinuxTun) {
+            addLog("Routing policy bypass CIDR rules are currently enforced only in Linux TUN mode")
+        }
     }
 
     private suspend fun startWindowsTun(socksPort: Int, requestGeneration: Long) {

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopDnsResolver.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopDnsResolver.kt
@@ -1,0 +1,32 @@
+package org.olcbox.app.vpn.desktop
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal object DesktopDnsResolver {
+    private const val DEFAULT_DNS = "1.1.1.1:53"
+
+    fun olcRtcDns(): String {
+        return normalizeDns(System.getenv("OLCBOX_DNS"))
+            ?: resolvConfDns(Path.of("/etc/resolv.conf"))
+            ?: DEFAULT_DNS
+    }
+
+    internal fun resolvConfDns(path: Path): String? {
+        return runCatching {
+            Files.readAllLines(path)
+                .asSequence()
+                .map { it.substringBefore('#').trim() }
+                .filter { it.startsWith("nameserver ") }
+                .mapNotNull { normalizeDns(it.removePrefix("nameserver").trim()) }
+                .firstOrNull()
+        }.getOrNull()
+    }
+
+    internal fun normalizeDns(value: String?): String? {
+        val trimmed = value?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        if (trimmed.startsWith("[") && "]:" in trimmed) return trimmed
+        if (trimmed.count { it == ':' } > 1) return "[$trimmed]:53"
+        return if (':' in trimmed) trimmed else "$trimmed:53"
+    }
+}

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyController.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.olcbox.app.desktop.DesktopOs
 import org.olcbox.app.desktop.DesktopPaths
+import java.net.URI
 
 internal interface DesktopProxyController {
     suspend fun enable(pacUrl: String)
@@ -39,6 +40,7 @@ internal class MacOsProxyController : DesktopProxyController {
     private var backup: List<MacOsAutoProxyState>? = null
 
     override suspend fun enable(pacUrl: String) {
+        validatePacUrl(pacUrl)
         val services = enabledNetworkServices()
         backup = services.map { service ->
             readAutoProxyState(service)
@@ -113,6 +115,7 @@ internal class WindowsProxyController : DesktopProxyController {
     private var backup: WindowsProxyState? = null
 
     override suspend fun enable(pacUrl: String) {
+        validatePacUrl(pacUrl)
         backup = readState()
         enableCommands(pacUrl).forEach { runCommand(it) }
         refreshProxySettings()
@@ -201,6 +204,15 @@ internal class WindowsProxyController : DesktopProxyController {
             return listOf("powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script)
         }
     }
+}
+
+internal fun validatePacUrl(pacUrl: String) {
+    val uri = runCatching { URI(pacUrl.trim()) }
+        .getOrElse { throw IllegalArgumentException("Invalid PAC URL") }
+    require(uri.scheme == "http" || uri.scheme == "https") { "PAC URL must use http or https scheme" }
+    require(uri.host?.isNotBlank() == true) { "PAC URL must include a host" }
+    require(uri.userInfo == null) { "PAC URL must not include credentials" }
+    require(uri.fragment == null) { "PAC URL must not include a fragment" }
 }
 
 private suspend fun runCommand(command: List<String>): String = withContext(Dispatchers.IO) {

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/LinuxTunController.kt
@@ -3,6 +3,7 @@ package org.olcbox.app.vpn.desktop
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.olcbox.app.data.routing.Ipv4Cidr
 import org.olcbox.app.desktop.DesktopPaths
 import java.nio.file.Files
 import java.nio.file.Path
@@ -14,13 +15,16 @@ internal class LinuxTunController(
     private val addLog: (String) -> Unit
 ) {
     private var routesInstalled = false
+    private var activeBypassCidrs = emptyList<Ipv4Cidr>()
 
     suspend fun start(
         hevBinary: Path,
-        socksPort: Int = PacServer.LOCAL_SOCKS_PORT
+        socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
+        bypassCidrs: List<Ipv4Cidr> = emptyList()
     ): Process {
-        val upScript = writeUpScript()
-        val downScript = writeDownScript()
+        activeBypassCidrs = bypassCidrs
+        val upScript = writeUpScript(bypassCidrs)
+        val downScript = writeDownScript(bypassCidrs)
         val config = writeConfig(socksPort, upScript, downScript)
         val process = startPrivilegedProcess(listOf(hevBinary.toString(), config.toString()))
         try {
@@ -30,6 +34,9 @@ internal class LinuxTunController(
             return process
         } catch (e: Exception) {
             stop(process)
+            runCatching { runPrivilegedScript(writeDownScript(activeBypassCidrs)) }
+                .onFailure { addLog("Linux TUN partial route cleanup failed: ${it.message}") }
+            activeBypassCidrs = emptyList()
             throw e
         }
     }
@@ -39,11 +46,10 @@ internal class LinuxTunController(
 
         if (routesInstalled) {
             waitForRoutesRemoved()
-            if (routeRuleExists()) {
-                runCatching { runPrivilegedScript(writeDownScript()) }
-                    .onFailure { addLog("Linux TUN route cleanup failed: ${it.message}") }
-            }
+            runCatching { runPrivilegedScript(writeDownScript(activeBypassCidrs)) }
+                .onFailure { addLog("Linux TUN route cleanup failed: ${it.message}") }
             routesInstalled = false
+            activeBypassCidrs = emptyList()
         }
     }
 
@@ -60,17 +66,17 @@ internal class LinuxTunController(
         return config
     }
 
-    private fun writeUpScript(): Path {
+    private fun writeUpScript(bypassCidrs: List<Ipv4Cidr>): Path {
         return writeScript(
             name = "linux-tun-up.sh",
-            body = upScriptContent()
+            body = upScriptContent(bypassCidrs)
         )
     }
 
-    private fun writeDownScript(): Path {
+    private fun writeDownScript(bypassCidrs: List<Ipv4Cidr>): Path {
         return writeScript(
             name = "linux-tun-down.sh",
-            body = downScriptContent()
+            body = downScriptContent(bypassCidrs)
         )
     }
 
@@ -177,6 +183,7 @@ internal class LinuxTunController(
         const val MAPDNS_NETMASK = "255.192.0.0"
         const val ROUTE_TABLE = "51820"
         const val ROOT_BYPASS_RULE_PREF = "10"
+        const val CIDR_BYPASS_RULE_PREF_BASE = 11
         const val TUN_RULE_PREF = "20"
         const val TUN_READY_TIMEOUT_MS = 10_000L
         const val TUN_READY_POLL_MS = 100L
@@ -227,7 +234,18 @@ internal class LinuxTunController(
             }.trimEnd()
         }
 
-        fun upScriptContent(): String {
+        fun upScriptContent(bypassCidrs: List<Ipv4Cidr> = emptyList()): String {
+            val bypassRuleLines = bypassCidrs
+                .take(MAX_BYPASS_CIDR_RULES)
+                .flatMapIndexed { index, cidr ->
+                    val pref = CIDR_BYPASS_RULE_PREF_BASE + index
+                    listOf(
+                        "ip rule del to ${cidr.value} lookup main pref $pref 2>/dev/null || true",
+                        "ip rule add to ${cidr.value} lookup main pref $pref"
+                    )
+                }
+                .joinToString("\n")
+
             return """
                 #!/bin/sh
                 set -eu
@@ -238,6 +256,7 @@ internal class LinuxTunController(
                 sysctl -w net.ipv4.conf.$TUN_NAME.rp_filter=0 >/dev/null 2>&1 || true
                 ip link set $TUN_NAME up
                 ip rule add uidrange 0-0 lookup main pref $ROOT_BYPASS_RULE_PREF
+$bypassRuleLines
                 ip route add default dev $TUN_NAME table $ROUTE_TABLE
                 ip rule add lookup $ROUTE_TABLE pref $TUN_RULE_PREF
                 if command -v resolvectl >/dev/null 2>&1; then
@@ -248,10 +267,19 @@ internal class LinuxTunController(
             """.trimIndent()
         }
 
-        fun downScriptContent(): String {
+        fun downScriptContent(bypassCidrs: List<Ipv4Cidr> = emptyList()): String {
+            val bypassRuleLines = bypassCidrs
+                .take(MAX_BYPASS_CIDR_RULES)
+                .mapIndexed { index, cidr ->
+                    val pref = CIDR_BYPASS_RULE_PREF_BASE + index
+                    "ip rule del to ${cidr.value} lookup main pref $pref 2>/dev/null || true"
+                }
+                .joinToString("\n")
+
             return """
                 #!/bin/sh
                 ip rule del uidrange 0-0 lookup main pref $ROOT_BYPASS_RULE_PREF 2>/dev/null || true
+$bypassRuleLines
                 ip rule del lookup $ROUTE_TABLE pref $TUN_RULE_PREF 2>/dev/null || true
                 ip route flush table $ROUTE_TABLE 2>/dev/null || true
                 if command -v resolvectl >/dev/null 2>&1; then
@@ -259,6 +287,8 @@ internal class LinuxTunController(
                 fi
             """.trimIndent()
         }
+
+        private const val MAX_BYPASS_CIDR_RULES = 64
     }
 }
 

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/OlcRtcCommand.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/OlcRtcCommand.kt
@@ -10,6 +10,7 @@ internal data class OlcRtcCommand(
     val socksPort: Int = PacServer.LOCAL_SOCKS_PORT,
     val socksUser: String = "",
     val socksPass: String = "",
+    val dnsServer: String = DesktopDnsResolver.olcRtcDns(),
     val dataDir: Path? = null
 ) {
     fun args(configPath: Path): List<String> {
@@ -31,7 +32,7 @@ internal data class OlcRtcCommand(
             appendLine("  key: ${config.key.yamlValue()}")
             appendLine("net:")
             appendLine("  transport: ${config.transport.yamlValue()}")
-            appendLine("  dns: \"1.1.1.1:53\"")
+            appendLine("  dns: ${dnsServer.yamlValue()}")
             if (config.bypassProvider == LocationConfig.PROVIDER_JITSI) {
                 appendLine("tls:")
                 appendLine("  insecure_skip_verify: true")

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -1,6 +1,7 @@
 package org.olcbox.app.vpn.desktop
 
 import org.olcbox.app.data.model.LocationConfig
+import org.olcbox.app.data.routing.Ipv4Cidr
 import org.olcbox.app.vpn.olcRtcNativeLibrarySpec
 import java.nio.file.Files
 import java.nio.file.Path
@@ -327,14 +328,17 @@ class DesktopProxyModeTest {
 
     @Test
     fun linuxTunScriptsRouteUserTrafficThroughTunAndKeepRootDirect() {
-        val up = LinuxTunController.upScriptContent()
-        val down = LinuxTunController.downScriptContent()
+        val bypassCidrs = listOf(Ipv4Cidr("10.0.0.0/8", "10.0.0.0", 8))
+        val up = LinuxTunController.upScriptContent(bypassCidrs)
+        val down = LinuxTunController.downScriptContent(bypassCidrs)
 
         assertContains(up, "ip rule add uidrange 0-0 lookup main pref 10")
+        assertContains(up, "ip rule add to 10.0.0.0/8 lookup main pref 11")
         assertContains(up, "ip route add default dev olcbox0 table 51820")
         assertContains(up, "ip rule add lookup 51820 pref 20")
         assertContains(up, "resolvectl dns olcbox0 1.1.1.1")
         assertContains(down, "ip rule del uidrange 0-0 lookup main pref 10")
+        assertContains(down, "ip rule del to 10.0.0.0/8 lookup main pref 11")
         assertContains(down, "ip route flush table 51820")
         assertContains(down, "resolvectl revert olcbox0")
     }

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/desktop/DesktopProxyModeTest.kt
@@ -2,10 +2,12 @@ package org.olcbox.app.vpn.desktop
 
 import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.vpn.olcRtcNativeLibrarySpec
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class DesktopProxyModeTest {
@@ -60,7 +62,8 @@ class DesktopProxyModeTest {
                 binary = Path.of("/tmp/olcrtc"),
                 location = LocationConfig("Test", "room-$provider", "b".repeat(64), provider),
                 socksHost = "127.0.0.1",
-                socksPort = 10808
+                socksPort = 10808,
+                dnsServer = "127.0.0.53:53"
             )
             val args = command.args(Path.of("/tmp/client.yaml"))
             val yaml = command.yaml()
@@ -69,6 +72,7 @@ class DesktopProxyModeTest {
             assertContains(yaml, "mode: cnc")
             assertContains(yaml, "provider: '${OlcRtcCommand.desktopProviderArg(provider)}'")
             assertContains(yaml, "transport: '$expectedTransport'")
+            assertContains(yaml, "dns: '127.0.0.53:53'")
             assertContains(yaml, "id: 'room-$provider'")
             assertContains(yaml, "port: 10808")
             if (LocationConfig.normalizeProvider(provider) == LocationConfig.PROVIDER_JITSI) {
@@ -100,10 +104,12 @@ class DesktopProxyModeTest {
                 bypassProvider = LocationConfig.PROVIDER_WB_STREAM,
                 transport = LocationConfig.TRANSPORT_DATACHANNEL
             ),
+            dnsServer = "10.0.0.2:53",
             dataDir = Path.of("/tmp/olcbox-data")
         ).yaml()
 
         assertContains(command, "transport: '${LocationConfig.TRANSPORT_DATACHANNEL}'")
+        assertContains(command, "dns: '10.0.0.2:53'")
         assertTrue("vp8:" !in command)
         assertContains(command, "data: '/tmp/olcbox-data'")
     }
@@ -204,6 +210,22 @@ class DesktopProxyModeTest {
     }
 
     @Test
+    fun pacUrlValidationRejectsNonHttpAndUnsafeUrls() {
+        validatePacUrl("http://127.0.0.1:10809/proxy.pac")
+        validatePacUrl("https://example.test/proxy.pac")
+
+        assertFailsWith<IllegalArgumentException> {
+            validatePacUrl("file:///tmp/proxy.pac")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validatePacUrl("http://user:pass@example.test/proxy.pac")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validatePacUrl("http://example.test/proxy.pac#fragment")
+        }
+    }
+
+    @Test
     fun windowsProxyCommandsBackupShapeIsRestorable() {
         val enable = WindowsProxyController.enableCommands("http://127.0.0.1:10809/proxy.pac")
         assertEquals("reg", enable.first().first())
@@ -248,6 +270,28 @@ class DesktopProxyModeTest {
         assertContains(config, "udp: 'tcp'")
         assertContains(config, "mapdns:")
         assertContains(config, "network: 100.64.0.0")
+    }
+
+    @Test
+    fun desktopDnsResolverUsesFirstResolvableNameserver() {
+        val file = Files.createTempFile("olcbox-resolv", ".conf")
+        try {
+            Files.writeString(
+                file,
+                """
+                # generated
+                search lan
+                nameserver 127.0.0.53
+                nameserver 9.9.9.9
+                """.trimIndent()
+            )
+
+            assertEquals("127.0.0.53:53", DesktopDnsResolver.resolvConfDns(file))
+            assertEquals("9.9.9.9:5353", DesktopDnsResolver.normalizeDns("9.9.9.9:5353"))
+            assertEquals("[2001:4860:4860::8888]:53", DesktopDnsResolver.normalizeDns("2001:4860:4860::8888"))
+        } finally {
+            Files.deleteIfExists(file)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Что изменилось

- Android TUN теперь отправляет UDP через SOCKS relay вместо принудительного UDP-over-TCP.
- Добавлены проверки PAC URL и автоопределение DNS для desktop olcRTC команд.
- JVM update/download теперь используют активный tunnel proxy, когда он доступен.
- Перенесено iOS background keepalive/reconnect поведение, чтобы туннель лучше переживал фон.
- GitHub workflows снова checkout'ят upstream/original olcrtc repos; добавлен `workflow_dispatch` для запуска PR Checks через `gh`.
- Добавлена основа routing policy для discussion #50:
  - `routing.split_tunnel`;
  - ссылки на `.dat` списки;
  - правила `domain`, `domain_suffix`, `ip_cidr`, `geosite`, `geoip`;
  - import/export/refresh/manual edit сохраняют routing policy;
  - matcher для static domain/IP rules;
  - planner runtime layer, который отделяет route-level CIDR rules от DNS/.dat rules;
  - `geoip:private`, `geoip:lan`, `geoip:local` разворачиваются в private/reserved IPv4 CIDR rules;
  - domain/geosite/.dat правила разделяются по `proxy`/`bypass` в resolver-level plan.
- Android 13+ применяет bypass `ip_cidr` через `VpnService.Builder.excludeRoute`.
- Linux TUN применяет bypass `ip_cidr` через high-priority `ip rule to <cidr> lookup main`.
- Android/Linux TUN используют включенный `mapdns` path для hostname matching внутри SOCKS path.
- UI показывает краткий routing summary для локации.
- Добавлена документация `docs/routing-policy.md`.

## Что закрывает

- Помогает #8 / #105: включает реальный SOCKS UDP path на Android при наличии olcrtc с UDP ASSOCIATE.
- Помогает #108: убирает hardcoded desktop DNS path и валидирует PAC URL.
- Помогает #95: добавляет iOS keepalive/reconnect path.
- Начинает discussion #50: routing policy сохраняется, показывается и частично применяется для route-level CIDR/mapdns-aware planning.

## Совместимость

Android UDP path требует olcrtc build с SOCKS5 UDP ASSOCIATE. Со старыми olcrtc бинарями полноценный UDP relay работать не будет.

Hostname-based `proxy` rules могут использовать mapdns/SOCKS hostname path, когда трафик уже внутри TUN. Hostname-based `bypass` rules все еще требуют native direct-route support: Android `VpnService.Builder` умеет исключать статические IP prefixes, но не умеет динамически исключать домен после DNS resolution.

`geosite` и внешние `.dat` ссылки сохраняются и попадают в runtime plan, но этот PR пока не скачивает и не парсит сторонние `.dat` базы. Country-wide `geoip`, например `geoip:ru`, тоже требует GeoIP CIDR bundle. `geoip:private/lan/local` уже разворачивается в CIDR и применяется как route-level rule.

## Проверка

- `git diff --check`
- Fork-side GitHub CLI build: https://github.com/cyber-debug/olcbox/actions/runs/28724234268
  - `PR Checks` / `Gradle checks`: passed.
  - Запустил `:sharedUI:jvmTest :desktopApp:compileKotlin :androidApp:assembleDebug`.
  - Собрал и загрузил `Olcbox-android-debug` artifact.
- GitGuardian passed on #112.
- Upstream #112 Actions могут быть `action_required`, потому PR из fork и upstream требует maintainer approval для workflow.
