### PR TITLE
feat: add subscription routing policy foundation

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: pr-checks-${{ github.event.pull_request.number }}
+  group: pr-checks-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
@@ -339,7 +339,8 @@ class LocationsRepositoryImpl(
                 storageId = normalizedId,
                 location = location,
                 subscriptionUrl = current?.subscriptionUrl,
-                metadata = current?.metadata
+                metadata = current?.metadata,
+                routing = current?.routing
             )
             val locations = bundle.locations
                 .filterNot { it.storageId == entry.storageId } + entry

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
@@ -329,6 +329,106 @@ data class LocationMetadata(
 }
 
 @Serializable
+enum class RoutingSplitTunnelMode {
+    @SerialName("full_tunnel")
+    FullTunnel,
+
+    @SerialName("proxy_selected")
+    ProxySelected,
+
+    @SerialName("bypass_selected")
+    BypassSelected
+}
+
+@Serializable
+enum class RoutingRuleAction {
+    @SerialName("proxy")
+    Proxy,
+
+    @SerialName("bypass")
+    Bypass
+}
+
+@Serializable
+enum class RoutingRuleType {
+    @SerialName("domain")
+    Domain,
+
+    @SerialName("domain_suffix")
+    DomainSuffix,
+
+    @SerialName("ip_cidr")
+    IpCidr,
+
+    @SerialName("geosite")
+    GeoSite,
+
+    @SerialName("geoip")
+    GeoIp
+}
+
+@Serializable
+data class RoutingDatListConfig(
+    val name: String = "",
+    val url: String = "",
+    val categories: List<String> = emptyList(),
+    val action: RoutingRuleAction = RoutingRuleAction.Proxy
+) {
+    fun normalized(): RoutingDatListConfig {
+        return copy(
+            name = name.trim(),
+            url = url.trim(),
+            categories = categories.cleanedRoutingValues()
+        )
+    }
+
+    fun isEmpty(): Boolean {
+        return name.isBlank() && url.isBlank() && categories.isEmpty()
+    }
+}
+
+@Serializable
+data class RoutingRuleConfig(
+    val type: RoutingRuleType = RoutingRuleType.DomainSuffix,
+    val value: String = "",
+    val action: RoutingRuleAction = RoutingRuleAction.Proxy
+) {
+    fun normalized(): RoutingRuleConfig {
+        return copy(value = value.trim())
+    }
+
+    fun isEmpty(): Boolean = value.isBlank()
+}
+
+@Serializable
+data class RoutingPolicyConfig(
+    @SerialName("split_tunnel")
+    val splitTunnel: RoutingSplitTunnelMode = RoutingSplitTunnelMode.FullTunnel,
+    @SerialName("dat_lists")
+    val datLists: List<RoutingDatListConfig> = emptyList(),
+    val rules: List<RoutingRuleConfig> = emptyList()
+) {
+    fun normalized(): RoutingPolicyConfig {
+        return copy(
+            datLists = datLists
+                .map { it.normalized() }
+                .filterNot { it.isEmpty() }
+                .distinctBy { "${it.name}|${it.url}|${it.categories.joinToString(",")}|${it.action}" },
+            rules = rules
+                .map { it.normalized() }
+                .filterNot { it.isEmpty() }
+                .distinctBy { "${it.type}|${it.value}|${it.action}" }
+        )
+    }
+
+    fun isEmpty(): Boolean {
+        return splitTunnel == RoutingSplitTunnelMode.FullTunnel &&
+                datLists.isEmpty() &&
+                rules.isEmpty()
+    }
+}
+
+@Serializable
 data class LocationEntry(
     @SerialName("storage_id")
     val storageId: String,
@@ -342,6 +442,7 @@ data class LocationEntry(
     val legacyCarrier: String? = null,
     val transport: LocationTransportConfig? = null,
     val metadata: LocationMetadata? = null,
+    val routing: RoutingPolicyConfig? = null,
     @SerialName("subscriptionUrl")
     val legacySubscriptionUrl: String? = null,
     @SerialName("id")
@@ -418,6 +519,9 @@ data class LocationEntry(
             transport = LocationTransportConfig.from(config),
             metadata = metadata
                 ?.normalized()
+                ?.takeUnless { it.isEmpty() },
+            routing = routing
+                ?.normalized()
                 ?.takeUnless { it.isEmpty() }
         )
     }
@@ -427,7 +531,8 @@ data class LocationEntry(
             storageId: String,
             location: LocationConfig,
             subscriptionUrl: String? = null,
-            metadata: LocationMetadata? = null
+            metadata: LocationMetadata? = null,
+            routing: RoutingPolicyConfig? = null
         ): LocationEntry {
             val config = location.normalized()
             return LocationEntry(
@@ -440,7 +545,8 @@ data class LocationEntry(
                 ),
                 authProvider = config.bypassProvider,
                 transport = LocationTransportConfig.from(config),
-                metadata = metadata
+                metadata = metadata,
+                routing = routing
             ).normalized()
         }
 
@@ -452,6 +558,11 @@ data class LocationEntry(
 
 private fun String?.cleanMetadataValue(): String? {
     return this?.trim()?.takeIf { it.isNotEmpty() }
+}
+
+private fun List<String>.cleanedRoutingValues(): List<String> {
+    return mapNotNull { value -> value.trim().takeIf { it.isNotEmpty() } }
+        .distinct()
 }
 
 @Serializable

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcher.kt
@@ -1,0 +1,93 @@
+package org.olcbox.app.data.routing
+
+import org.olcbox.app.data.model.RoutingPolicyConfig
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleConfig
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
+
+enum class RoutingDecision {
+    Proxy,
+    Bypass
+}
+
+object RoutingPolicyMatcher {
+    fun decide(
+        policy: RoutingPolicyConfig?,
+        host: String? = null,
+        ip: String? = null
+    ): RoutingDecision {
+        val normalizedPolicy = policy?.normalized() ?: return RoutingDecision.Proxy
+        val normalizedHost = host.normalizedHost()
+        val ipValue = ip?.trim()?.takeIf { it.isNotEmpty() }
+        val matchedAction = normalizedPolicy.rules
+            .firstOrNull { rule -> rule.matches(normalizedHost, ipValue) }
+            ?.action
+
+        return when (matchedAction) {
+            RoutingRuleAction.Proxy -> RoutingDecision.Proxy
+            RoutingRuleAction.Bypass -> RoutingDecision.Bypass
+            null -> normalizedPolicy.defaultDecision()
+        }
+    }
+
+    private fun RoutingPolicyConfig.defaultDecision(): RoutingDecision {
+        return when (splitTunnel) {
+            RoutingSplitTunnelMode.FullTunnel,
+            RoutingSplitTunnelMode.BypassSelected -> RoutingDecision.Proxy
+            RoutingSplitTunnelMode.ProxySelected -> RoutingDecision.Bypass
+        }
+    }
+
+    private fun RoutingRuleConfig.matches(host: String?, ip: String?): Boolean {
+        val ruleValue = value.trim()
+        if (ruleValue.isBlank()) return false
+
+        return when (type) {
+            RoutingRuleType.Domain -> host != null && host == ruleValue.normalizedHost()
+            RoutingRuleType.DomainSuffix -> host != null && host.matchesDomainSuffix(ruleValue)
+            RoutingRuleType.IpCidr -> ip != null && ipv4InCidr(ip, ruleValue)
+            RoutingRuleType.GeoSite,
+            RoutingRuleType.GeoIp -> false
+        }
+    }
+
+    private fun String?.normalizedHost(): String? {
+        return this
+            ?.trim()
+            ?.removeSuffix(".")
+            ?.lowercase()
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun String.matchesDomainSuffix(ruleValue: String): Boolean {
+        val suffix = ruleValue.normalizedHost() ?: return false
+        return this == suffix || endsWith(".$suffix")
+    }
+
+    private fun ipv4InCidr(ip: String, cidr: String): Boolean {
+        val separator = cidr.indexOf('/')
+        if (separator <= 0 || separator == cidr.lastIndex) return false
+
+        val network = parseIpv4(cidr.substring(0, separator).trim()) ?: return false
+        val prefix = cidr.substring(separator + 1).trim().toIntOrNull() ?: return false
+        if (prefix !in 0..32) return false
+
+        val address = parseIpv4(ip) ?: return false
+        val mask = if (prefix == 0) 0 else (-1 shl (32 - prefix))
+        return (address and mask) == (network and mask)
+    }
+
+    private fun parseIpv4(value: String): Int? {
+        val parts = value.trim().split('.')
+        if (parts.size != 4) return null
+
+        var result = 0
+        for (part in parts) {
+            val octet = part.toIntOrNull() ?: return null
+            if (octet !in 0..255) return null
+            result = (result shl 8) or octet
+        }
+        return result
+    }
+}

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/datasource/LocationsRepositoryImplTest.kt
@@ -11,6 +11,9 @@ import org.olcbox.app.data.identity.DeviceIdentityProvider
 import org.olcbox.app.data.model.LocationBundleV4
 import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.model.LocationEntry
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
 import org.olcbox.app.data.share.ConfigShareService
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -367,6 +370,87 @@ class LocationsRepositoryImplTest {
         assertNotNull(imported)
         assertEquals(LocationConfig.TRANSPORT_VP8CHANNEL, imported.locations[0].location.transport)
         assertEquals(LocationConfig.TRANSPORT_DATACHANNEL, imported.locations[1].location.transport)
+    }
+
+    @Test
+    fun importsExportsAndPreservesSubscriptionRoutingPolicy() = runTest {
+        val source = FakeLocationsDataSource()
+        val input = """
+            {
+              "version": 5,
+              "active_location_id": "ru",
+              "locations": [
+                {
+                  "storage_id": "ru",
+                  "name": "RU",
+                  "endpoint": {
+                    "room_id": "room-ru",
+                    "key": "${"e".repeat(64)}"
+                  },
+                  "auth_provider": "wbstream",
+                  "transport": {
+                    "type": "vp8channel"
+                  },
+                  "routing": {
+                    "split_tunnel": "bypass_selected",
+                    "dat_lists": [
+                      {
+                        "name": "ru-sites",
+                        "url": "https://example.test/geosite.dat",
+                        "categories": ["geosite:ru", " geosite:vk ", "geosite:ru"],
+                        "action": "bypass"
+                      }
+                    ],
+                    "rules": [
+                      {
+                        "type": "domain_suffix",
+                        "value": "youtube.com",
+                        "action": "proxy"
+                      },
+                      {
+                        "type": "ip_cidr",
+                        "value": "10.0.0.0/8",
+                        "action": "bypass"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val repository = LocationsRepositoryImpl(source)
+        repository.importText(input)
+
+        val imported = source.stored
+        assertNotNull(imported)
+        val routing = imported.locations.single().routing
+        assertNotNull(routing)
+        assertEquals(RoutingSplitTunnelMode.BypassSelected, routing.splitTunnel)
+        assertEquals(listOf("geosite:ru", "geosite:vk"), routing.datLists.single().categories)
+        assertEquals(RoutingRuleAction.Bypass, routing.datLists.single().action)
+        assertEquals(RoutingRuleType.DomainSuffix, routing.rules[0].type)
+        assertEquals("youtube.com", routing.rules[0].value)
+        assertEquals(RoutingRuleType.IpCidr, routing.rules[1].type)
+
+        val exported = repository.exportBundle()
+        assertTrue("\"routing\"" in exported)
+        assertTrue("\"dat_lists\"" in exported)
+
+        repository.saveLocation(
+            storageId = "ru",
+            location = LocationConfig(
+                name = "RU updated",
+                id = "room-ru",
+                key = "f".repeat(64),
+                bypassProvider = LocationConfig.PROVIDER_WB_STREAM
+            )
+        )
+
+        val updatedRouting = source.stored?.locations?.single()?.routing
+        assertNotNull(updatedRouting)
+        assertEquals(RoutingSplitTunnelMode.BypassSelected, updatedRouting.splitTunnel)
+        assertEquals("https://example.test/geosite.dat", updatedRouting.datLists.single().url)
     }
 
     @Test

--- a/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
+++ b/sharedUI/src/commonTest/kotlin/org/olcbox/app/data/routing/RoutingPolicyMatcherTest.kt
@@ -1,0 +1,95 @@
+package org.olcbox.app.data.routing
+
+import org.olcbox.app.data.model.RoutingPolicyConfig
+import org.olcbox.app.data.model.RoutingRuleAction
+import org.olcbox.app.data.model.RoutingRuleConfig
+import org.olcbox.app.data.model.RoutingRuleType
+import org.olcbox.app.data.model.RoutingSplitTunnelMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoutingPolicyMatcherTest {
+    @Test
+    fun defaultsToProxyForFullTunnelAndBypassSelectedModes() {
+        assertEquals(
+            RoutingDecision.Proxy,
+            RoutingPolicyMatcher.decide(RoutingPolicyConfig(splitTunnel = RoutingSplitTunnelMode.FullTunnel))
+        )
+        assertEquals(
+            RoutingDecision.Proxy,
+            RoutingPolicyMatcher.decide(RoutingPolicyConfig(splitTunnel = RoutingSplitTunnelMode.BypassSelected))
+        )
+    }
+
+    @Test
+    fun defaultsToBypassForProxySelectedMode() {
+        assertEquals(
+            RoutingDecision.Bypass,
+            RoutingPolicyMatcher.decide(RoutingPolicyConfig(splitTunnel = RoutingSplitTunnelMode.ProxySelected))
+        )
+    }
+
+    @Test
+    fun matchesDomainAndDomainSuffixRules() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.ProxySelected,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.Domain,
+                    value = "api.example.com",
+                    action = RoutingRuleAction.Proxy
+                ),
+                RoutingRuleConfig(
+                    type = RoutingRuleType.DomainSuffix,
+                    value = "youtube.com",
+                    action = RoutingRuleAction.Proxy
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "API.EXAMPLE.COM."))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "www.youtube.com"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "youtube.com"))
+        assertEquals(RoutingDecision.Bypass, RoutingPolicyMatcher.decide(policy, host = "notyoutube.com"))
+    }
+
+    @Test
+    fun matchesIpv4CidrRules() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.FullTunnel,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.IpCidr,
+                    value = "10.32.0.0/12",
+                    action = RoutingRuleAction.Bypass
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Bypass, RoutingPolicyMatcher.decide(policy, ip = "10.47.255.1"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "10.48.0.1"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "not-an-ip"))
+    }
+
+    @Test
+    fun leavesGeoRulesForDatResolver() {
+        val policy = RoutingPolicyConfig(
+            splitTunnel = RoutingSplitTunnelMode.FullTunnel,
+            rules = listOf(
+                RoutingRuleConfig(
+                    type = RoutingRuleType.GeoSite,
+                    value = "geosite:youtube",
+                    action = RoutingRuleAction.Bypass
+                ),
+                RoutingRuleConfig(
+                    type = RoutingRuleType.GeoIp,
+                    value = "geoip:private",
+                    action = RoutingRuleAction.Bypass
+                )
+            )
+        )
+
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, host = "youtube.com"))
+        assertEquals(RoutingDecision.Proxy, RoutingPolicyMatcher.decide(policy, ip = "10.0.0.1"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a subscription `routing` policy schema for split-tunnel intent, `.dat` list references, and explicit static rules
- preserve routing policy data through JSON import/export, subscription refresh, and manual location edits
- add a common routing matcher for explicit `domain`, `domain_suffix`, and `ip_cidr` rules
- keep `geosite`/`geoip` as schema-level data for a future `.dat` resolver instead of silently faking matches
- add `workflow_dispatch` to PR checks so branch builds can be triggered with GitHub CLI

## Scope
This starts discussion #50 without changing olcrtc. The app can now accept and preserve routing policy from subscriptions, and common code can evaluate static domain/IP rules.

Runtime `.dat` enforcement still needs a resolver/cache layer wired into the TUN/DNS path. This PR intentionally does not pretend that `geosite`/`geoip` works before that resolver exists.

## Validation
- `git diff --check`
- Fork-side GitHub CLI build: https://github.com/cyber-debug/olcbox/actions/runs/28722974109
  - `PR Checks` / `Gradle checks` passed in 9m20s.
  - Ran `:sharedUI:jvmTest :desktopApp:compileKotlin :androidApp:assembleDebug`.
- GitGuardian passed on #113.
- Upstream #113 Actions are still `action_required` because this PR is from a fork and upstream requires maintainer approval before workflows run there.
