### PR TITLE
fix(android): use upstream network DNS instead of hardcoded 1.1.1.1

### DIFF
--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/OlcRtcConnectionChecker.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/OlcRtcConnectionChecker.kt
@@ -81,6 +81,6 @@ internal object OlcRtcConnectionChecker {
     private const val CONNECTION_CHECK_TIMEOUT_MS = 8_000L
 
     private const val HTTP_PING_ATTEMPTS = 1
-    private const val HTTP_PING_TIMEOUT_MS = 8_000L
+    private const val HTTP_PING_TIMEOUT_MS = 30_000L
     private const val HTTP_PING_URL = "https://www.google.com/generate_204"
 }

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -586,7 +586,7 @@ class OlcboxVpnService : VpnService() {
             }
             waitForJitsiRoomCleanup(config.bypassProvider)
             bindProcessToNetwork(upstream, "Bound to ${getNetName(upstream)}")
-            configureMobileTransport(config)
+            configureMobileTransport(config, upstream)
             addLog(
                 "Starting olcRTC provider=${config.bypassProvider}, " +
                     "transport=${config.transport}, room=${config.id}"
@@ -655,13 +655,25 @@ class OlcboxVpnService : VpnService() {
         delay(waitMs)
     }
 
-    private fun configureMobileTransport(location: LocationConfig) {
+    private fun configureMobileTransport(location: LocationConfig, upstream: Network) {
         val config = location.normalized()
         Mobile.setProviders()
         Mobile.setTransport(config.transport)
-        Mobile.setDNS("1.1.1.1:53")
+        Mobile.setDNS("${readUpstreamDns(upstream)}:53")
         Mobile.setSocksListenHost(socksListenHost)
         Mobile.setVP8Options(config.vp8Fps.toLong(), config.vp8Batch.toLong())
+    }
+
+    private fun readUpstreamDns(network: Network): String {
+        return try {
+            connectivityManager.getLinkProperties(network)
+                ?.dnsServers
+                ?.firstOrNull { !it.isLoopbackAddress }
+                ?.hostAddress
+                ?: "1.1.1.1"
+        } catch (e: Exception) {
+            "1.1.1.1"
+        }
     }
 
     private fun startTun2socks(pfd: ParcelFileDescriptor): Boolean {

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/OlcRtcConnectionChecker.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/OlcRtcConnectionChecker.kt
@@ -392,7 +392,7 @@ internal object OlcRtcConnectionChecker {
     private const val CONNECTION_CHECK_ATTEMPTS = 2
     private const val HTTP_PING_ATTEMPTS = 1
 
-    private const val OLC_READY_TIMEOUT_MS = 8_000L
+    private const val OLC_READY_TIMEOUT_MS = 25_000L
     private const val READY_POLL_INTERVAL_MS = 100L
     private const val TCP_CONNECT_TIMEOUT_MS = 250L
 


### PR DESCRIPTION
## Summary

`configureMobileTransport()` always called `Mobile.setDNS("1.1.1.1:53")`, regardless of the active network. This breaks connectivity in environments where `1.1.1.1` is unreachable:

- Captive portals (hotel/airport Wi-Fi) that require DNS through their own resolver
- Corporate networks with internal-only DNS
- ISPs that block external DNS servers

**Fix:** read the actual DNS server from the upstream network via `ConnectivityManager.getLinkProperties()` before the tunnel is brought up. The `upstream` network reference is already available at the call site — `bindProcessToNetwork` is called just before `configureMobileTransport`. Falls back to `1.1.1.1` if the upstream DNS cannot be determined.

```kotlin
private fun readUpstreamDns(network: Network): String {
    return try {
        connectivityManager.getLinkProperties(network)
            ?.dnsServers
            ?.firstOrNull { !it.isLoopbackAddress }
            ?.hostAddress
            ?: "1.1.1.1"
    } catch (e: Exception) {
        "1.1.1.1"
    }
}
```

## Additional changes

Increased olcRTC ready timeouts to better handle slow ICE negotiation over TURN relay:

- `HTTP_PING_TIMEOUT_MS`: 8 s → 30 s (Android, `androidMain/OlcRtcConnectionChecker`)
- `OLC_READY_TIMEOUT_MS`: 8 s → 25 s (JVM, `jvmMain/OlcRtcConnectionChecker`)

With TURN relay (e.g. Telemost), ICE negotiation can take 10–20 s, causing a false "Offline" result with the previous 8 s timeout.

## Test plan

- [x] Connected on home Wi-Fi — tunnel up, DNS resolves correctly
- [x] Connected on mobile network — tunnel up, DNS resolves correctly
- [x] Fallback to `1.1.1.1` when `getLinkProperties()` returns null — no crash