### PR TITLE
feat(ios): add VPN (packet-tunnel) mode alongside proxy mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ keystore.properties
 release-keystore.jks
 .!80165!.DS_Store
 .zed
+
+# iOS: hev tun2socks xcframework is built by the PacketTunnel pre-build phase
+iosApp/Frameworks/

--- a/androidApp/src/main/jni/hev-socks5-tunnel/build-apple-ios.sh
+++ b/androidApp/src/main/jni/hev-socks5-tunnel/build-apple-ios.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Trimmed variant of build-apple.sh: iOS device + arm64 simulator only.
+# Outputs straight to iosApp/Frameworks/, where the Xcode project expects it.
+set -e
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../../../../.. && pwd)"
+OUTPUT_XCFRAMEWORK="$REPO_ROOT/iosApp/Frameworks/HevSocks5Tunnel.xcframework"
+
+XCFRAMEWORK_DIR="./apple_xcframework"
+
+buildStatic()
+{
+     echo "build for $1, $2, min version $3"
+     local MIN_VERSION="-m$1-version-min=$3"
+     make PP="xcrun --sdk $1 --toolchain $1 clang" \
+          CC="xcrun --sdk $1 --toolchain $1 clang" \
+          CFLAGS="-arch $2 $MIN_VERSION" \
+          LFLAGS="-arch $2 $MIN_VERSION -Wl,-Bsymbolic-functions" static
+     local OUTPUT_DIR="$XCFRAMEWORK_DIR/$1-$2"
+     mkdir -p $OUTPUT_DIR
+     local OUTPUT_ARCH_FILE="$OUTPUT_DIR/libhev-socks5-tunnel.a"
+     libtool -static -o $OUTPUT_ARCH_FILE \
+                   bin/libhev-socks5-tunnel.a \
+                   third-part/lwip/bin/liblwip.a \
+                   third-part/yaml/bin/libyaml.a \
+                   third-part/hev-task-system/bin/libhev-task-system.a
+     make clean
+}
+
+rm -rf $XCFRAMEWORK_DIR
+rm -rf "$OUTPUT_XCFRAMEWORK"
+mkdir -p "$(dirname "$OUTPUT_XCFRAMEWORK")"
+mkdir $XCFRAMEWORK_DIR
+
+buildStatic iphoneos arm64 15.0
+buildStatic iphonesimulator arm64 15.0
+
+INCLUDE_DIR="$XCFRAMEWORK_DIR/include"
+mkdir -p $INCLUDE_DIR
+cp ./src/hev-main.h $INCLUDE_DIR
+cp ./module.modulemap $INCLUDE_DIR
+xcodebuild -create-xcframework \
+    -library ./apple_xcframework/iphoneos-arm64/libhev-socks5-tunnel.a -headers $INCLUDE_DIR \
+    -library ./apple_xcframework/iphonesimulator-arm64/libhev-socks5-tunnel.a -headers $INCLUDE_DIR \
+    -output "$OUTPUT_XCFRAMEWORK"
+
+rm -rf ./apple_xcframework
+echo "DONE $OUTPUT_XCFRAMEWORK"

--- a/androidApp/src/main/jni/hev-socks5-tunnel/src/hev-socks5-tunnel.c
+++ b/androidApp/src/main/jni/hev-socks5-tunnel/src/hev-socks5-tunnel.c
@@ -690,7 +690,7 @@ hev_socks5_tunnel_run (void)
 void
 hev_socks5_tunnel_stop (void)
 {
-    int res;
+    int res = 0;
     int fd;
 
     LOG_D ("socks5 tunnel stop");

--- a/docs/ios-vpn-mode.md
+++ b/docs/ios-vpn-mode.md
@@ -1,0 +1,86 @@
+# iOS VPN (TUN) mode
+
+Adds a full-device tunnel mode on iOS, alongside the existing local-SOCKS5 proxy
+mode. Mirrors Android's TUN path but through Apple's `NEPacketTunnelProvider`.
+
+## Data path
+
+```
+device packets → utun fd → hev-socks5-tunnel (lwIP tun2socks)
+              → 127.0.0.1:socksPort (olcRTC local SOCKS5, hosted in the extension)
+              → olcRTC WebRTC relay → internet
+```
+
+Everything runs **inside the Network Extension process** so it survives app
+suspension — unlike proxy mode, which keeps the app alive with a silent-audio hack
+(`SilentAudioKeepAlive`). This is the same reason WireGuard/Outline host their engine
+in-extension on iOS.
+
+## Components
+
+| Piece | File |
+| --- | --- |
+| Packet-tunnel provider | `iosApp/PacketTunnel/PacketTunnelProvider.swift` |
+| Extension Info.plist / entitlements | `iosApp/PacketTunnel/{Info.plist,PacketTunnel.entitlements}` |
+| App-side VPN control | `iosApp/iosApp/SwiftTunnelManager.swift` (impl of `IosTunnelBridge`) |
+| App entitlements | `iosApp/iosApp/iosApp.entitlements` |
+| Shared bridge/types | `sharedUI/.../ios/IosBridge.kt` (`IosTunnelBridge`, `IosTunnelStartRequest`) |
+| Mode enum | `sharedUI/.../vpn/IosConnectionMode.kt` |
+| Mode logic | `sharedUI/.../vpn/IosVpnManager.kt` (TUN branch, status mapping) |
+| Mode UI toggle | `sharedUI/.../ui/components/ApplicationSettingsSheet.kt` + `MainViewController.kt` |
+| tun2socks engine (iOS) | `HevSocks5Tunnel.xcframework` built from `androidApp/src/main/jni/hev-socks5-tunnel/build-apple-ios.sh` |
+
+The olcRTC engine reuses the existing gomobile symbols (`MobileStartWithTransport`,
+`MobileWaitReady`, `MobileStop`), so no change to the `olcrtc` Go repo is required.
+`hev_socks5_tunnel_main_from_str(config, len, tunFd)` adopts the utun fd directly
+(`tunnel_init` sets it non-blocking when `>= 0`).
+
+> One upstream fix was needed for the stricter Xcode 26 clang:
+> `hev-socks5-tunnel/src/hev-socks5-tunnel.c` initialises `res` before
+> `write(fd, &res, 1)` (was `-Werror,-Wuninitialized-const-pointer`).
+
+## Build
+
+The extension's pre-build phase "Build Native Frameworks" prepares both engines:
+
+1. `HevSocks5Tunnel.xcframework` — built by `build-apple-ios.sh` (outputs straight
+   to `iosApp/Frameworks/`) only when the xcframework is not already there; delete
+   it (or run the script manually) to force a rebuild after changing hev sources.
+2. `OlcRtcMobile.xcframework` via `./gradlew :sharedUI:buildOlcrtcIosXcframework`
+   (needs the `olcrtc` Go repo at `../olcrtc` or `$OLCRTC_REPO`, Go ≥ 1.26.3, and
+   `gomobile`/`gobind` on `$HOME/go/bin`).
+
+The `PacketTunnel` target itself is generated: after touching
+`iosApp/add_packet_tunnel_target.rb`, re-run `ruby add_packet_tunnel_target.rb`
+from `iosApp/` (idempotent) and commit the resulting `project.pbxproj`.
+
+Then `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp`. The app and the
+`PacketTunnel.appex` are code-signed externally (both targets have
+`CODE_SIGNING_ALLOWED = NO`, matching the existing CI/unsigned-IPA flow).
+
+## Apple provisioning (required to run on device)
+
+A packet-tunnel extension cannot use a wildcard profile. On the team's developer
+portal, create:
+
+- **App ID** `org.olcbox.app.ios` — enable *Network Extensions* + *App Groups*.
+- **App ID** `org.olcbox.app.ios.PacketTunnel` — same two capabilities.
+- **App Group** `group.org.olcbox.app` — assign to both App IDs.
+- Development provisioning profiles for both App IDs including the test device.
+
+The entitlements files already declare `packet-tunnel-provider` and the
+`group.org.olcbox.app` group. Change the group/bundle IDs consistently if a
+different team prefix is used (`SwiftTunnelManager.extensionBundleId`,
+`PacketTunnelProvider` OSLog subsystem, both `.entitlements`, both Info.plists).
+
+## Known risks / follow-ups
+
+- **Extension memory budget.** Go + Pion WebRTC + lwIP in one NE extension is heavy
+  (NE budget ≈ 50 MB). Needs on-device validation; if it OOMs, trim the Go build or
+  move heavy allocation out of the hot path.
+- **Routing loop.** The design relies on iOS excluding the provider's own sockets
+  from its tunnel (as Outline does). If relay traffic loops, install a protector via
+  `MobileSetProtector` that binds engine sockets to the physical interface
+  (`IP_BOUND_IF`) — the Go side already routes every dial through
+  `internal/protect.Protector`.
+- **Mode switch while connected** stops and restarts the tunnel/proxy.

--- a/iosApp/PacketTunnel/Info.plist
+++ b/iosApp/PacketTunnel/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Olcbox Tunnel</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.networkextension.packet-tunnel</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).PacketTunnelProvider</string>
+	</dict>
+</dict>
+</plist>

--- a/iosApp/PacketTunnel/PacketTunnel.entitlements
+++ b/iosApp/PacketTunnel/PacketTunnel.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.networking.networkextension</key>
+	<array>
+		<string>packet-tunnel-provider</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.olcbox.app</string>
+	</array>
+</dict>
+</plist>

--- a/iosApp/PacketTunnel/PacketTunnelProvider.swift
+++ b/iosApp/PacketTunnel/PacketTunnelProvider.swift
@@ -1,0 +1,309 @@
+import Darwin
+import Foundation
+import NetworkExtension
+import OlcRtcMobile
+import HevSocks5Tunnel
+import os
+
+/// Full-tunnel (VPN) mode for iOS.
+///
+/// This is the iOS analogue of Android's `OlcboxVpnService`. The whole data path
+/// lives inside this Network Extension process so that it keeps running while the
+/// host app is suspended (which is exactly what the proxy mode's silent-audio hack
+/// works around, and what a real VPN must not depend on):
+///
+///   device packets -> utun fd -> hev-socks5-tunnel (lwIP tun2socks)
+///                  -> 127.0.0.1:socksPort (olcRTC local SOCKS5, hosted here)
+///                  -> olcRTC WebRTC relay -> internet
+///
+/// The olcRTC engine (`OlcRtcMobile`, gomobile) opens the local SOCKS5 listener in
+/// this process; hev-socks5-tunnel converts the utun IP stream into SOCKS5 sessions
+/// against that listener. Config (carrier/room/key/socks creds) is handed over by
+/// the app through `protocolConfiguration.providerConfiguration`.
+final class PacketTunnelProvider: NEPacketTunnelProvider {
+    private let log = OSLog(subsystem: "org.olcbox.app.ios.PacketTunnel", category: "tunnel")
+    private let hevQueue = DispatchQueue(label: "org.olcbox.packettunnel.hev")
+    // Both flags are touched from the provider's calling thread (start/stopTunnel)
+    // and from hevQueue, so every access goes through stateLock.
+    private let stateLock = NSLock()
+    private var hevRunning = false
+    private var stopped = false
+
+    // MARK: NEPacketTunnelProvider
+
+    override func startTunnel(
+        options: [String: NSObject]?,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        let config: TunnelConfig
+        do {
+            config = try TunnelConfig(protocolConfiguration: protocolConfiguration)
+        } catch {
+            os_log("invalid tunnel configuration: %{public}@", log: log, type: .error, "\(error)")
+            completionHandler(error)
+            return
+        }
+
+        os_log("starting olcRTC SOCKS in-extension (carrier=%{public}@ transport=%{public}@ port=%d)",
+               log: log, type: .info, config.carrierName, config.transportName, config.socksPort)
+
+        // 1. Start the olcRTC engine's local SOCKS5 listener inside this process.
+        if let error = startOlcRtc(config) {
+            os_log("olcRTC start failed: %{public}@", log: log, type: .error, "\(error)")
+            completionHandler(error)
+            return
+        }
+
+        // 2. Configure the utun interface (address, DNS, default route). iOS owns the
+        //    interface addressing here (unlike Android/macOS where hev sets it), so the
+        //    hev YAML only needs MTU + SOCKS upstream.
+        let settings = makeNetworkSettings(config)
+        setTunnelNetworkSettings(settings) { [weak self] error in
+            guard let self else { return }
+            if let error {
+                os_log("setTunnelNetworkSettings failed: %{public}@", log: self.log, type: .error, "\(error)")
+                MobileStop()
+                completionHandler(error)
+                return
+            }
+
+            // 3. Adopt the utun fd and hand it to hev-socks5-tunnel.
+            guard let tunFd = self.tunnelFileDescriptor() else {
+                let err = NSError(domain: "PacketTunnel", code: 1,
+                                  userInfo: [NSLocalizedDescriptionKey: "utun fd not found"])
+                os_log("utun fd not found", log: self.log, type: .error)
+                MobileStop()
+                completionHandler(err)
+                return
+            }
+
+            self.startHev(tunFd: tunFd, config: config)
+            os_log("tunnel up", log: self.log, type: .info)
+            completionHandler(nil)
+        }
+    }
+
+    override func stopTunnel(
+        with reason: NEProviderStopReason,
+        completionHandler: @escaping () -> Void
+    ) {
+        os_log("stopping tunnel (reason=%d)", log: log, type: .info, reason.rawValue)
+        stateLock.lock()
+        stopped = true
+        let quitHev = hevRunning
+        hevRunning = false
+        stateLock.unlock()
+        if quitHev {
+            hev_socks5_tunnel_quit()
+        }
+        MobileStop()
+        completionHandler()
+    }
+
+    // MARK: olcRTC engine (local SOCKS5)
+
+    private func startOlcRtc(_ config: TunnelConfig) -> Error? {
+        MobileSetProviders()
+        MobileSetTransport(config.transportName)
+        MobileSetDNS(config.dns)
+        MobileSetVP8Options(Int(config.vp8Fps), Int(config.vp8BatchSize))
+
+        if MobileIsRunning() {
+            MobileStop()
+        }
+
+        var error: NSError?
+        let started = MobileStartWithTransport(
+            config.carrierName,
+            config.transportName,
+            config.roomId,
+            config.clientId,
+            config.keyHex,
+            Int(config.socksPort),
+            config.socksUser,
+            config.socksPass,
+            &error
+        )
+        guard started else {
+            return error ?? NSError(domain: "PacketTunnel", code: 2,
+                                    userInfo: [NSLocalizedDescriptionKey: "olcRTC start failed"])
+        }
+
+        let ready = MobileWaitReady(8_000, &error)
+        guard ready else {
+            MobileStop()
+            return error ?? NSError(domain: "PacketTunnel", code: 3,
+                                    userInfo: [NSLocalizedDescriptionKey: "olcRTC start timed out"])
+        }
+        return nil
+    }
+
+    // MARK: hev-socks5-tunnel
+
+    private func startHev(tunFd: Int32, config: TunnelConfig) {
+        let yaml = hevConfigYAML(config)
+        // hev_socks5_tunnel_main_from_str blocks until _quit; run it off the provider
+        // thread. It dups nothing — it adopts `tunFd` directly (tunnel_init sets it
+        // non-blocking and marks it non-local, so it will not close our utun fd).
+        // Strong self on purpose: hev outlives any provider callback, and the block
+        // must observe stopped/hevRunning through the same instance stopTunnel uses.
+        hevQueue.async {
+            self.stateLock.lock()
+            if self.stopped {
+                // stopTunnel won the race before hev's main ever ran; starting it now
+                // would leave it running with no one to quit it.
+                self.stateLock.unlock()
+                return
+            }
+            self.hevRunning = true
+            self.stateLock.unlock()
+
+            var rc: Int32 = 0
+            yaml.withCString { cstr in
+                let len = UInt32(strlen(cstr))
+                cstr.withMemoryRebound(to: UInt8.self, capacity: Int(len)) { bytes in
+                    rc = hev_socks5_tunnel_main_from_str(bytes, len, tunFd)
+                }
+            }
+
+            self.stateLock.lock()
+            let wasStopped = self.stopped
+            self.hevRunning = false
+            self.stateLock.unlock()
+            os_log("hev exited rc=%d", log: self.log, type: .info, rc)
+            if !wasStopped {
+                // hev died on its own (bad config, fd error) — without this the
+                // tunnel stays "connected" with a dead data path.
+                let err = NSError(domain: "PacketTunnel", code: 4,
+                                  userInfo: [NSLocalizedDescriptionKey: "hev-socks5-tunnel exited (rc=\(rc))"])
+                self.cancelTunnelWithError(err)
+            }
+        }
+    }
+
+    /// YAML single-quoted scalar: the only escape is doubling embedded quotes.
+    private func yamlQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "''") + "'"
+    }
+
+    private func hevConfigYAML(_ config: TunnelConfig) -> String {
+        // The utun fd is passed directly, so `tunnel.name`/`ipv4` are ignored on iOS;
+        // interface addressing is done by NEPacketTunnelNetworkSettings above.
+        return """
+        tunnel:
+          mtu: \(config.mtu)
+
+        socks5:
+          address: 127.0.0.1
+          port: \(config.socksPort)
+          udp: 'tcp'
+          pipeline: false
+          username: \(yamlQuoted(config.socksUser))
+          password: \(yamlQuoted(config.socksPass))
+
+        mapdns:
+          address: \(config.dnsAddress)
+          port: 53
+          network: 100.64.0.0
+          netmask: 255.192.0.0
+          cache-size: 10000
+
+        misc:
+          task-stack-size: 24576
+          tcp-buffer-size: 4096
+          max-session-count: 1200
+          connect-timeout: 10000
+          tcp-read-write-timeout: 300000
+          udp-read-write-timeout: 60000
+          log-file: stderr
+          log-level: warn
+        """
+    }
+
+    // MARK: utun interface
+
+    private func makeNetworkSettings(_ config: TunnelConfig) -> NEPacketTunnelNetworkSettings {
+        let settings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: "127.0.0.1")
+
+        let ipv4 = NEIPv4Settings(addresses: ["10.0.88.88"], subnetMasks: ["255.255.255.0"])
+        ipv4.includedRoutes = [NEIPv4Route.default()]
+        settings.ipv4Settings = ipv4
+
+        let dns = NEDNSSettings(servers: [config.dnsAddress])
+        // Force all DNS through the tunnel so hev's mapdns can resolve via SOCKS.
+        dns.matchDomains = [""]
+        settings.dnsSettings = dns
+
+        settings.mtu = NSNumber(value: config.mtu)
+        return settings
+    }
+
+    /// Finds the utun file descriptor owned by this provider by probing every open fd
+    /// for the UTUN_OPT_IFNAME control-socket option (the same identification hev uses
+    /// internally). This is the standard NEPacketTunnelProvider technique, because the
+    /// API exposes packets via `packetFlow` but not the raw fd hev needs.
+    private func tunnelFileDescriptor() -> Int32? {
+        // SYSPROTO_CONTROL = 2, UTUN_OPT_IFNAME = 2 (from <sys/sys_domain.h> /
+        // <net/if_utun.h>); used as literals to avoid extra C module imports.
+        for fd: Int32 in 0...1024 {
+            var name = [CChar](repeating: 0, count: Int(IFNAMSIZ))
+            var len = socklen_t(name.count)
+            let ret = getsockopt(fd, 2, 2, &name, &len)
+            if ret == 0 && String(cString: name).hasPrefix("utun") {
+                return fd
+            }
+        }
+        return nil
+    }
+}
+
+/// Parsed provider configuration handed over by the containing app.
+private struct TunnelConfig {
+    let carrierName: String
+    let transportName: String
+    let roomId: String
+    let clientId: String
+    let keyHex: String
+    let socksPort: Int
+    let socksUser: String
+    let socksPass: String
+    let vp8Fps: Int
+    let vp8BatchSize: Int
+    let mtu: Int
+    let dns: String          // "1.1.1.1:53" for the olcRTC engine
+    let dnsAddress: String    // "1.1.1.1" for NEDNSSettings / hev mapdns
+
+    init(protocolConfiguration: NEVPNProtocol?) throws {
+        guard
+            let proto = protocolConfiguration as? NETunnelProviderProtocol,
+            let dict = proto.providerConfiguration
+        else {
+            throw NSError(domain: "PacketTunnel", code: 10,
+                          userInfo: [NSLocalizedDescriptionKey: "missing providerConfiguration"])
+        }
+        func str(_ key: String) throws -> String {
+            guard let v = dict[key] as? String else {
+                throw NSError(domain: "PacketTunnel", code: 11,
+                              userInfo: [NSLocalizedDescriptionKey: "missing key: \(key)"])
+            }
+            return v
+        }
+        func intVal(_ key: String, _ fallback: Int) -> Int {
+            (dict[key] as? NSNumber)?.intValue ?? Int(dict[key] as? String ?? "") ?? fallback
+        }
+
+        carrierName = try str("carrierName")
+        transportName = try str("transportName")
+        roomId = try str("roomId")
+        clientId = try str("clientId")
+        keyHex = try str("keyHex")
+        socksPort = intVal("socksPort", 10808)
+        socksUser = (dict["socksUser"] as? String) ?? ""
+        socksPass = (dict["socksPass"] as? String) ?? ""
+        vp8Fps = intVal("vp8Fps", 30)
+        vp8BatchSize = intVal("vp8BatchSize", 8)
+        mtu = intVal("mtu", 1500)
+        dnsAddress = (dict["dnsAddress"] as? String) ?? "1.1.1.1"
+        dns = "\(dnsAddress):53"
+    }
+}

--- a/iosApp/add_packet_tunnel_target.rb
+++ b/iosApp/add_packet_tunnel_target.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+# Adds the PacketTunnel (NEPacketTunnelProvider) app-extension target to the
+# Olcbox iOS project, links the hev + olcRTC xcframeworks into it, embeds it in
+# the app, and wires entitlements/app-group. Idempotent: re-running removes an
+# existing PacketTunnel target first.
+require 'xcodeproj'
+
+PROJECT   = File.expand_path(File.join(__dir__, 'iosApp.xcodeproj'))
+APP_NAME  = 'iosApp'
+EXT_NAME  = 'PacketTunnel'
+EXT_BID   = 'org.olcbox.app.ios.PacketTunnel'
+APP_GROUP = 'group.org.olcbox.app'
+
+proj = Xcodeproj::Project.open(PROJECT)
+app  = proj.targets.find { |t| t.name == APP_NAME } or abort("app target #{APP_NAME} not found")
+
+# --- clean any previous run -------------------------------------------------
+proj.targets.select { |t| t.name == EXT_NAME }.each do |old|
+  app.dependencies.select { |d| d.target == old }.each(&:remove_from_project)
+  old.remove_from_project
+end
+
+# embed phase, extension product, and every file reference a previous run added
+# to the app side — removing only the target (as before) left all of these
+# behind and duplicated them on each re-run.
+app.build_phases.grep(Xcodeproj::Project::Object::PBXCopyFilesBuildPhase)
+   .select { |ph| ph.name == 'Embed App Extensions' }
+   .each(&:remove_from_project)
+proj.products_group.files
+    .select { |f| f.display_name == "#{EXT_NAME}.appex" }
+    .each(&:remove_from_project)
+stale_paths = [
+  'PacketTunnel/PacketTunnelProvider.swift',
+  'PacketTunnel/Info.plist',
+  'PacketTunnel/PacketTunnel.entitlements',
+  'iosApp/SwiftTunnelManager.swift',
+  'Frameworks/HevSocks5Tunnel.xcframework',
+  '../sharedUI/build/generated/olcrtc/ios/OlcRtcMobile.xcframework',
+]
+proj.files.select { |f| stale_paths.include?(f.path) }.each do |f|
+  f.build_files.each(&:remove_from_project)
+  f.remove_from_project
+end
+# Foundation.framework ref that new_target adds for the extension (upstream has none)
+proj.files.select { |f| f.display_name == 'Foundation.framework' }.each do |f|
+  f.build_files.each(&:remove_from_project)
+  f.remove_from_project
+end
+
+# --- create the extension target -------------------------------------------
+ext = proj.new_target(:app_extension, EXT_NAME, :ios, '15.0', proj.products_group, :swift)
+
+ext.build_configurations.each do |c|
+  bs = c.build_settings
+  bs['PRODUCT_BUNDLE_IDENTIFIER']            = EXT_BID
+  bs['PRODUCT_NAME']                         = '$(TARGET_NAME)'
+  bs['INFOPLIST_FILE']                       = 'PacketTunnel/Info.plist'
+  bs['CODE_SIGN_ENTITLEMENTS']               = 'PacketTunnel/PacketTunnel.entitlements'
+  bs['GENERATE_INFOPLIST_FILE']              = 'NO'
+  bs['SWIFT_VERSION']                        = '6.0'
+  bs['TARGETED_DEVICE_FAMILY']               = '1,2'
+  bs['IPHONEOS_DEPLOYMENT_TARGET']           = '15.0'
+  bs['CODE_SIGNING_ALLOWED']                 = 'NO'
+  bs['CODE_SIGN_STYLE']                      = 'Automatic'
+  bs['SKIP_INSTALL']                         = 'YES'
+  bs['ENABLE_BITCODE']                       = 'NO'
+  bs['ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES'] = 'NO'
+  bs['SWIFT_OBJC_INTEROP_MODE']              = 'objcxx' rescue nil
+  # -lresolv + Security/CoreFoundation: the gomobile OlcRtcMobile Go runtime needs
+  # libresolv (res_9_* DNS symbols) and these system frameworks. The app gets them
+  # transitively via the Kotlin/Native SharedUI framework; the extension links neither.
+  bs['OTHER_LDFLAGS'] = ['$(inherited)', '-ObjC', '-lresolv', '-framework', 'Security', '-framework', 'CoreFoundation']
+end
+
+# --- source files -----------------------------------------------------------
+provider_ref = proj.main_group.new_file('PacketTunnel/PacketTunnelProvider.swift')
+ext.source_build_phase.add_file_reference(provider_ref)
+# Info.plist / entitlements as references (visible in Xcode, not compiled)
+proj.main_group.new_file('PacketTunnel/Info.plist')
+proj.main_group.new_file('PacketTunnel/PacketTunnel.entitlements')
+
+# app-side controller into the app target
+tun_mgr_ref = proj.main_group.new_file('iosApp/SwiftTunnelManager.swift')
+app.source_build_phase.add_file_reference(tun_mgr_ref)
+
+# --- link xcframeworks into the extension -----------------------------------
+fw_group = proj.main_group.find_subpath('Frameworks', true)
+hev_ref  = fw_group.new_file('Frameworks/HevSocks5Tunnel.xcframework')
+# olcRTC xcframework is gradle-generated; reference the (future) build path.
+olc_ref  = fw_group.new_file('../sharedUI/build/generated/olcrtc/ios/OlcRtcMobile.xcframework')
+[hev_ref, olc_ref].each { |r| ext.frameworks_build_phase.add_file_reference(r) }
+
+# --- pre-build: ensure both native xcframeworks exist before compiling -------
+gradle_phase = ext.new_shell_script_build_phase('Build Native Frameworks')
+gradle_phase.shell_script = <<~SH
+  set -e
+  export PATH="$HOME/go/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+  if [ -z "$ARCHS" ] || [ "$ARCHS" = "undefined_arch" ]; then export ARCHS=arm64; fi
+  if [ ! -d "$SRCROOT/Frameworks/HevSocks5Tunnel.xcframework" ]; then
+    "$SRCROOT/../androidApp/src/main/jni/hev-socks5-tunnel/build-apple-ios.sh"
+  fi
+  cd "$SRCROOT/.."
+  ./gradlew :sharedUI:buildOlcrtcIosXcframework --no-configuration-cache
+SH
+# run it first, before Sources
+ext.build_phases.unshift(ext.build_phases.delete(gradle_phase))
+
+# --- embed extension into the app + dependency ------------------------------
+app.add_dependency(ext)
+embed = app.new_copy_files_build_phase('Embed App Extensions')
+embed.symbol_dst_subfolder_spec = :plug_ins
+appex = ext.product_reference
+build_file = embed.add_file_reference(appex)
+build_file.settings = { 'ATTRIBUTES' => ['RemoveHeadersOnCopy'] }
+
+# --- app entitlements (network extension + app group) -----------------------
+app.build_configurations.each do |c|
+  c.build_settings['CODE_SIGN_ENTITLEMENTS'] = 'iosApp/iosApp.entitlements'
+end
+
+proj.save
+puts "OK: added #{EXT_NAME} target, embedded in #{APP_NAME}"
+puts "targets now: #{proj.targets.map(&:name).join(', ')}"

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -7,20 +7,68 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C466350ADA74EE026BCCC9A /* PacketTunnelProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689CAB288C93845BCD62F31F /* PacketTunnelProvider.swift */; };
+		59A83FFCACAB6E64D87AE9B6 /* HevSocks5Tunnel.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF69E3D46F43591D43F0AF31 /* HevSocks5Tunnel.xcframework */; };
 		9A0000010000000000000001 /* OlcboxIosApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0000010000000000000011 /* OlcboxIosApp.swift */; };
 		9A0000010000000000000002 /* SwiftPlatformBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0000010000000000000012 /* SwiftPlatformBridge.swift */; };
 		9A0000010000000000000003 /* SwiftOlcRtcManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0000010000000000000013 /* SwiftOlcRtcManager.swift */; };
+		9FA44A189F67E76001ED44E7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A97A05AC8CA7C8BE770E3EC2 /* Foundation.framework */; };
+		A21EF0CFA16835E504E011C2 /* PacketTunnel.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 5F4CA9FCF9F787F9A3514302 /* PacketTunnel.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		B024911BCB3ED14A72B157DC /* SwiftTunnelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EF54C2FD6CB5B6B4956CA7 /* SwiftTunnelManager.swift */; };
+		C8BD57912ED0E265F2D81DE0 /* OlcRtcMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48F7D52CE6B222705F175D8D /* OlcRtcMobile.xcframework */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		AC7EF64A0EEF3119E9CCF212 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9A0000010000000000000090 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1A10B618E810F618B28CBD05;
+			remoteInfo = PacketTunnel;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A14FAB6527BA44BEBF37028B /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				A21EF0CFA16835E504E011C2 /* PacketTunnel.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		0902B156FC4B9B737FD80A7B /* PacketTunnel.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; name = PacketTunnel.entitlements; path = PacketTunnel/PacketTunnel.entitlements; sourceTree = "<group>"; };
+		48F7D52CE6B222705F175D8D /* OlcRtcMobile.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = OlcRtcMobile.xcframework; path = ../sharedUI/build/generated/olcrtc/ios/OlcRtcMobile.xcframework; sourceTree = "<group>"; };
+		56EF54C2FD6CB5B6B4956CA7 /* SwiftTunnelManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftTunnelManager.swift; path = iosApp/SwiftTunnelManager.swift; sourceTree = "<group>"; };
+		5F4CA9FCF9F787F9A3514302 /* PacketTunnel.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = PacketTunnel.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		689CAB288C93845BCD62F31F /* PacketTunnelProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PacketTunnelProvider.swift; path = PacketTunnel/PacketTunnelProvider.swift; sourceTree = "<group>"; };
 		9A0000010000000000000010 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A0000010000000000000011 /* OlcboxIosApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OlcboxIosApp.swift; sourceTree = "<group>"; };
 		9A0000010000000000000012 /* SwiftPlatformBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftPlatformBridge.swift; sourceTree = "<group>"; };
 		9A0000010000000000000013 /* SwiftOlcRtcManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftOlcRtcManager.swift; sourceTree = "<group>"; };
 		9A0000010000000000000014 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A97A05AC8CA7C8BE770E3EC2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		F98977E3727B2C27610ABFEA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = PacketTunnel/Info.plist; sourceTree = "<group>"; };
+		FF69E3D46F43591D43F0AF31 /* HevSocks5Tunnel.xcframework */ = {isa = PBXFileReference; includeInIndex = 1; name = HevSocks5Tunnel.xcframework; path = Frameworks/HevSocks5Tunnel.xcframework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		13A5F2E1FA79F817E2177224 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9FA44A189F67E76001ED44E7 /* Foundation.framework in Frameworks */,
+				59A83FFCACAB6E64D87AE9B6 /* HevSocks5Tunnel.xcframework in Frameworks */,
+				C8BD57912ED0E265F2D81DE0 /* OlcRtcMobile.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9A0000010000000000000020 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -31,12 +79,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6D90DEFD5527187674CC8863 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				A97A05AC8CA7C8BE770E3EC2 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		9A0000010000000000000030 = {
 			isa = PBXGroup;
 			children = (
 				9A0000010000000000000031 /* iosApp */,
 				9A0000010000000000000032 /* Frameworks */,
 				9A0000010000000000000033 /* Products */,
+				689CAB288C93845BCD62F31F /* PacketTunnelProvider.swift */,
+				F98977E3727B2C27610ABFEA /* Info.plist */,
+				0902B156FC4B9B737FD80A7B /* PacketTunnel.entitlements */,
+				56EF54C2FD6CB5B6B4956CA7 /* SwiftTunnelManager.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -54,6 +114,9 @@
 		9A0000010000000000000032 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6D90DEFD5527187674CC8863 /* iOS */,
+				FF69E3D46F43591D43F0AF31 /* HevSocks5Tunnel.xcframework */,
+				48F7D52CE6B222705F175D8D /* OlcRtcMobile.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -62,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				9A0000010000000000000010 /* iosApp.app */,
+				5F4CA9FCF9F787F9A3514302 /* PacketTunnel.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -69,6 +133,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1A10B618E810F618B28CBD05 /* PacketTunnel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DFBAF328F90176F2752CB962 /* Build configuration list for PBXNativeTarget "PacketTunnel" */;
+			buildPhases = (
+				C630B6577EECED0968DE94F2 /* Build Native Frameworks */,
+				04342FE57AEDD71D5B90BF42 /* Sources */,
+				13A5F2E1FA79F817E2177224 /* Frameworks */,
+				3618213BD1C413F31D08FF58 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PacketTunnel;
+			productName = PacketTunnel;
+			productReference = 5F4CA9FCF9F787F9A3514302 /* PacketTunnel.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		9A0000010000000000000040 /* iosApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9A0000010000000000000080 /* Build configuration list for PBXNativeTarget "iosApp" */;
@@ -77,10 +159,12 @@
 				9A0000010000000000000060 /* Sources */,
 				9A0000010000000000000020 /* Frameworks */,
 				9A0000010000000000000070 /* Resources */,
+				A14FAB6527BA44BEBF37028B /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				919C20DC632B3572A0BA49A0 /* PBXTargetDependency */,
 			);
 			name = iosApp;
 			productName = iosApp;
@@ -116,11 +200,19 @@
 			projectRoot = "";
 			targets = (
 				9A0000010000000000000040 /* iosApp */,
+				1A10B618E810F618B28CBD05 /* PacketTunnel */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3618213BD1C413F31D08FF58 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9A0000010000000000000070 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -146,9 +238,35 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\nexport PATH=\"$HOME/go/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\"\nif [ -z \"$ARCHS\" ] || [ \"$ARCHS\" = \"undefined_arch\" ]; then\n  export ARCHS=arm64\nfi\nGRADLE_VERSION_ARGS=\"\"\nif [ -n \"$OLCBOX_VERSION\" ]; then\n  GRADLE_VERSION_ARGS=\"-Polcbox.version=$OLCBOX_VERSION\"\nfi\ncd \"$SRCROOT/..\"\n./gradlew $GRADLE_VERSION_ARGS :sharedUI:buildOlcrtcIosXcframework :sharedUI:embedAndSignAppleFrameworkForXcode --no-configuration-cache\n";
 		};
+		C630B6577EECED0968DE94F2 /* Build Native Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build Native Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nexport PATH=\"$HOME/go/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\"\nif [ -z \"$ARCHS\" ] || [ \"$ARCHS\" = \"undefined_arch\" ]; then export ARCHS=arm64; fi\nif [ ! -d \"$SRCROOT/Frameworks/HevSocks5Tunnel.xcframework\" ]; then\n  \"$SRCROOT/../androidApp/src/main/jni/hev-socks5-tunnel/build-apple-ios.sh\"\nfi\ncd \"$SRCROOT/..\"\n./gradlew :sharedUI:buildOlcrtcIosXcframework --no-configuration-cache\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		04342FE57AEDD71D5B90BF42 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C466350ADA74EE026BCCC9A /* PacketTunnelProvider.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9A0000010000000000000060 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -156,12 +274,117 @@
 				9A0000010000000000000001 /* OlcboxIosApp.swift in Sources */,
 				9A0000010000000000000002 /* SwiftPlatformBridge.swift in Sources */,
 				9A0000010000000000000003 /* SwiftOlcRtcManager.swift in Sources */,
+				B024911BCB3ED14A72B157DC /* SwiftTunnelManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		919C20DC632B3572A0BA49A0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PacketTunnel;
+			target = 1A10B618E810F618B28CBD05 /* PacketTunnel */;
+			targetProxy = AC7EF64A0EEF3119E9CCF212 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		4CA8B96F81C2A3BEF6110F2F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = PacketTunnel/PacketTunnel.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_BITCODE = NO;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = PacketTunnel/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lresolv",
+					"-framework",
+					Security,
+					"-framework",
+					CoreFoundation,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.olcbox.app.ios.PacketTunnel;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		54AA35E422526C319A6F0B3F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = PacketTunnel/PacketTunnel.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_BITCODE = NO;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = PacketTunnel/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lresolv",
+					"-framework",
+					Security,
+					"-framework",
+					CoreFoundation,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.olcbox.app.ios.PacketTunnel;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6E6FF5290E3A63B053BC0D1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = PacketTunnel/PacketTunnel.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_BITCODE = NO;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = PacketTunnel/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lresolv",
+					"-framework",
+					Security,
+					"-framework",
+					CoreFoundation,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.olcbox.app.ios.PacketTunnel;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		9A00000100000000000000A0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -221,13 +444,12 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "";
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../sharedUI/build/generated/olcrtc/ios/OlcRtcMobile.xcframework/ios-arm64",
@@ -268,12 +490,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = iosApp/iosApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(inherited)",
 					"$(SRCROOT)/../sharedUI/build/generated/olcrtc/ios/OlcRtcMobile.xcframework/ios-arm64",
@@ -309,6 +530,37 @@
 			};
 			name = Release;
 		};
+		D9E48DEB3855563E3127155E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGN_ENTITLEMENTS = PacketTunnel/PacketTunnel.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				ENABLE_BITCODE = NO;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = PacketTunnel/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lresolv",
+					"-framework",
+					Security,
+					"-framework",
+					CoreFoundation,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.olcbox.app.ios.PacketTunnel;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_INTEROP_MODE = objcxx;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -329,6 +581,15 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
+		};
+		DFBAF328F90176F2752CB962 /* Build configuration list for PBXNativeTarget "PacketTunnel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4CA8B96F81C2A3BEF6110F2F /* Release */,
+				54AA35E422526C319A6F0B3F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/iosApp/iosApp/OlcboxIosApp.swift
+++ b/iosApp/iosApp/OlcboxIosApp.swift
@@ -5,16 +5,20 @@ import SharedUI
 struct OlcboxIosApp: App {
     private let platformBridge: SwiftPlatformBridge
     private let olcRtcBridge: SwiftOlcRtcManager
+    private let tunnelBridge: SwiftTunnelManager
     private let appSession: IosAppSession
 
     init() {
         let platformBridge = SwiftPlatformBridge()
         let olcRtcBridge = SwiftOlcRtcManager()
+        let tunnelBridge = SwiftTunnelManager()
         self.platformBridge = platformBridge
         self.olcRtcBridge = olcRtcBridge
+        self.tunnelBridge = tunnelBridge
         self.appSession = IosAppFactory().createSession(
             platformBridge: platformBridge,
-            olcRtcBridge: olcRtcBridge
+            olcRtcBridge: olcRtcBridge,
+            tunnelBridge: tunnelBridge
         )
     }
 

--- a/iosApp/iosApp/SwiftTunnelManager.swift
+++ b/iosApp/iosApp/SwiftTunnelManager.swift
@@ -1,0 +1,136 @@
+import Foundation
+import NetworkExtension
+import SharedUI
+
+/// App-side control surface for TUN (VPN) mode, implementing the shared
+/// `IosTunnelBridge`. It installs/loads a `NETunnelProviderManager` pointing at the
+/// PacketTunnel extension and starts/stops it. All data-path work happens inside the
+/// extension; this class only manages the VPN profile and relays status.
+final class SwiftTunnelManager: NSObject, IosTunnelBridge {
+    private static let extensionBundleId = "org.olcbox.app.ios.PacketTunnel"
+    private static let appGroup = "group.org.olcbox.app"
+
+    private var manager: NETunnelProviderManager?
+    private var statusListener: IosTunnelStatusListener?
+    private var configured = false
+
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(vpnStatusChanged(_:)),
+            name: .NEVPNStatusDidChange,
+            object: nil
+        )
+        reload()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: IosTunnelBridge
+
+    func setStatusListener(listener: IosTunnelStatusListener?) {
+        statusListener = listener
+    }
+
+    func isConfigured() -> Bool {
+        configured
+    }
+
+    func isActive() -> Bool {
+        switch manager?.connection.status {
+        case .connected, .connecting, .reasserting:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func start(request: IosTunnelStartRequest, callback: IosMessageCallback) {
+        NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
+            guard let self else { return }
+            if let error {
+                callback.onError(message: "Load VPN preferences failed: \(error.localizedDescription)")
+                return
+            }
+            let manager = managers?.first ?? NETunnelProviderManager()
+            manager.localizedDescription = "Olcbox"
+            manager.protocolConfiguration = self.makeProtocol(request)
+            manager.isEnabled = true
+
+            manager.saveToPreferences { saveError in
+                if let saveError {
+                    callback.onError(message: "Save VPN profile failed: \(saveError.localizedDescription)")
+                    return
+                }
+                // Apple quirk: reload after save before starting, or startVPNTunnel throws.
+                manager.loadFromPreferences { loadError in
+                    if let loadError {
+                        callback.onError(message: "Reload VPN profile failed: \(loadError.localizedDescription)")
+                        return
+                    }
+                    self.manager = manager
+                    self.configured = true
+                    do {
+                        try manager.connection.startVPNTunnel()
+                        callback.onSuccess(message: "started")
+                    } catch {
+                        callback.onError(message: "Start tunnel failed: \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+
+    func stop() {
+        manager?.connection.stopVPNTunnel()
+    }
+
+    // MARK: Helpers
+
+    private func makeProtocol(_ request: IosTunnelStartRequest) -> NETunnelProviderProtocol {
+        let proto = NETunnelProviderProtocol()
+        proto.providerBundleIdentifier = Self.extensionBundleId
+        // Not a real remote host; the extension talks to the olcRTC relay itself.
+        proto.serverAddress = "olcRTC"
+        proto.providerConfiguration = [
+            "carrierName": request.carrierName,
+            "transportName": request.transportName,
+            "roomId": request.roomId,
+            "clientId": request.clientId,
+            "keyHex": request.keyHex,
+            "socksPort": NSNumber(value: request.socksPort),
+            "socksUser": request.socksUser,
+            "socksPass": request.socksPass,
+            "vp8Fps": NSNumber(value: request.vp8Fps),
+            "vp8BatchSize": NSNumber(value: request.vp8BatchSize),
+            "mtu": NSNumber(value: request.mtu),
+            "dnsAddress": request.dnsAddress
+        ]
+        return proto
+    }
+
+    private func reload() {
+        NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, _ in
+            guard let self else { return }
+            self.manager = managers?.first
+            self.configured = (self.manager != nil)
+        }
+    }
+
+    @objc private func vpnStatusChanged(_ note: Notification) {
+        let status: String
+        switch manager?.connection.status ?? .invalid {
+        case .invalid: status = "invalid"
+        case .disconnected: status = "disconnected"
+        case .connecting: status = "connecting"
+        case .connected: status = "connected"
+        case .reasserting: status = "reconnecting"
+        case .disconnecting: status = "disconnecting"
+        @unknown default: status = "invalid"
+        }
+        statusListener?.onStatus(status: status, message: nil)
+    }
+}

--- a/iosApp/iosApp/iosApp.entitlements
+++ b/iosApp/iosApp/iosApp.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.networking.networkextension</key>
+	<array>
+		<string>packet-tunnel-provider</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.olcbox.app</string>
+	</array>
+</dict>
+</plist>

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/components/ApplicationSettingsSheet.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/components/ApplicationSettingsSheet.kt
@@ -94,6 +94,14 @@ data class ApplicationSocksProxySettings(
     }
 }
 
+/** A selectable connection-mode option shown on the Connection Mode screen. */
+data class AppConnectionModeOption(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val selected: Boolean
+)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ApplicationSettingsSheet(
@@ -107,6 +115,9 @@ fun ApplicationSettingsSheet(
     connectionDetails: List<Pair<String, String>>,
     socksProxySettings: ApplicationSocksProxySettings? = null,
     isConnectionActive: Boolean = false,
+    connectionModeValue: String = "Proxy · Local SOCKS5",
+    connectionModeOptions: List<AppConnectionModeOption> = emptyList(),
+    onConnectionModeSelected: (String) -> Unit = {},
     onDismiss: () -> Unit,
     onCopyConfigClick: () -> Unit,
     onSaveLogsClick: () -> Unit,
@@ -172,12 +183,15 @@ fun ApplicationSettingsSheet(
                     summary = connectionSummary,
                     details = connectionDetails,
                     socksProxySettings = socksProxySettings,
+                    connectionModeValue = connectionModeValue,
                     onConnectionModeClick = { route = SharedSettingsRoute.ConnectionMode },
                     onSocksProxyClick = { route = SharedSettingsRoute.SocksProxy },
                     onBack = { route = SharedSettingsRoute.Hub }
                 )
 
                 SharedSettingsRoute.ConnectionMode -> SharedConnectionModeSettingsContent(
+                    options = connectionModeOptions,
+                    onSelect = onConnectionModeSelected,
                     onBack = { route = SharedSettingsRoute.Connection }
                 )
 
@@ -291,6 +305,7 @@ private fun SharedConnectionSettingsContent(
     summary: String,
     details: List<Pair<String, String>>,
     socksProxySettings: ApplicationSocksProxySettings?,
+    connectionModeValue: String,
     onConnectionModeClick: () -> Unit,
     onSocksProxyClick: () -> Unit,
     onBack: () -> Unit
@@ -312,7 +327,7 @@ private fun SharedConnectionSettingsContent(
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             SharedNavigationRow(
                 title = "Connection Mode",
-                value = "Proxy · Local SOCKS5",
+                value = connectionModeValue,
                 icon = Icons.Rounded.Public,
                 onClick = onConnectionModeClick
             )
@@ -337,6 +352,8 @@ private fun SharedConnectionSettingsContent(
 
 @Composable
 private fun SharedConnectionModeSettingsContent(
+    options: List<AppConnectionModeOption>,
+    onSelect: (String) -> Unit,
     onBack: () -> Unit
 ) {
     Column(
@@ -345,20 +362,36 @@ private fun SharedConnectionModeSettingsContent(
             .padding(horizontal = 24.dp)
             .padding(bottom = 32.dp)
     ) {
+        val subtitle = options.firstOrNull { it.selected }?.title ?: "Local SOCKS5 proxy"
         SharedDetailHeader(
             title = "Connection Mode",
-            subtitle = "Local SOCKS5 proxy",
+            subtitle = subtitle,
             onBack = onBack
         )
 
         Spacer(Modifier.height(20.dp))
 
-        SharedSelectableSettingsCard(
-            selected = true,
-            icon = Icons.Rounded.Public,
-            title = "Proxy",
-            subtitle = "Local SOCKS endpoint"
-        )
+        if (options.isEmpty()) {
+            // Platforms without a selectable mode (single fixed proxy).
+            SharedSelectableSettingsCard(
+                selected = true,
+                icon = Icons.Rounded.Public,
+                title = "Proxy",
+                subtitle = "Local SOCKS endpoint"
+            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                options.forEach { option ->
+                    SharedSelectableSettingsCard(
+                        selected = option.selected,
+                        icon = Icons.Rounded.Public,
+                        title = option.title,
+                        subtitle = option.subtitle,
+                        onClick = { onSelect(option.id) }
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -937,12 +970,14 @@ private fun SharedSelectableSettingsCard(
     selected: Boolean,
     icon: ImageVector,
     title: String,
-    subtitle: String
+    subtitle: String,
+    onClick: (() -> Unit)? = null
 ) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .height(82.dp),
+            .height(82.dp)
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier),
         shape = RoundedCornerShape(18.dp),
         color = if (selected) {
             MaterialTheme.colorScheme.secondaryContainer

--- a/sharedUI/src/iosMain/kotlin/org/olcbox/app/ios/IosBridge.kt
+++ b/sharedUI/src/iosMain/kotlin/org/olcbox/app/ios/IosBridge.kt
@@ -59,6 +59,57 @@ interface IosOlcRtcBridge {
     fun check(request: IosOlcRtcCheckRequest): IosLongResult
 }
 
+/**
+ * Start parameters for the packet-tunnel (VPN) mode. Mirrors [IosOlcRtcStartRequest]
+ * plus the extra fields the Network Extension needs to build its utun/hev config.
+ */
+data class IosTunnelStartRequest(
+    val carrierName: String,
+    val transportName: String,
+    val roomId: String,
+    val clientId: String,
+    val keyHex: String,
+    val socksPort: Int,
+    val socksUser: String,
+    val socksPass: String,
+    val vp8Fps: Int,
+    val vp8BatchSize: Int,
+    val mtu: Int,
+    val dnsAddress: String
+)
+
+interface IosTunnelStatusListener {
+    /**
+     * @param status one of: disconnected, connecting, connected, reconnecting,
+     *               disconnecting, invalid.
+     * @param message optional human-readable detail (e.g. an error).
+     */
+    fun onStatus(status: String, message: String?)
+}
+
+/**
+ * Swift-implemented control surface over `NETunnelProviderManager` for TUN mode.
+ * The extension itself hosts the olcRTC engine + hev-socks5-tunnel; this bridge only
+ * installs/loads the VPN profile and starts/stops it.
+ */
+interface IosTunnelBridge {
+    fun setStatusListener(listener: IosTunnelStatusListener?)
+
+    /** True if a saved VPN profile already exists (no permission prompt needed). */
+    fun isConfigured(): Boolean
+
+    /** True if the tunnel is currently connected or connecting. */
+    fun isActive(): Boolean
+
+    /**
+     * Installs (prompting for VPN permission the first time) and starts the tunnel.
+     * Reports the terminal outcome of the start attempt via [callback].
+     */
+    fun start(request: IosTunnelStartRequest, callback: IosMessageCallback)
+
+    fun stop()
+}
+
 interface IosPlatformBridge {
     fun readClipboard(): String?
     fun writeClipboard(text: String)

--- a/sharedUI/src/iosMain/kotlin/org/olcbox/app/ios/MainViewController.kt
+++ b/sharedUI/src/iosMain/kotlin/org/olcbox/app/ios/MainViewController.kt
@@ -22,6 +22,7 @@ import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.share.ConfigShareService
 import org.olcbox.app.data.share.SubscriptionShareItem
 import org.olcbox.app.ui.OlcboxAppContent
+import org.olcbox.app.ui.components.AppConnectionModeOption
 import org.olcbox.app.ui.components.ApplicationSettingsSheet
 import org.olcbox.app.ui.components.ApplicationUpdateOfferSheet
 import org.olcbox.app.ui.features.home.HomeScreenViewModel
@@ -37,30 +38,34 @@ import org.olcbox.app.update.identity
 import org.olcbox.app.update.isDownloaded
 import org.olcbox.app.update.isUpdateCheckDue
 import org.olcbox.app.update.shouldShowOffer
+import org.olcbox.app.vpn.IosConnectionMode
 import org.olcbox.app.vpn.IosVpnManager
 import platform.UIKit.UIViewController
 
 class IosAppFactory {
     fun createSession(
         platformBridge: IosPlatformBridge,
-        olcRtcBridge: IosOlcRtcBridge
+        olcRtcBridge: IosOlcRtcBridge,
+        tunnelBridge: IosTunnelBridge? = null
     ): IosAppSession {
-        return IosAppSession(platformBridge, olcRtcBridge)
+        return IosAppSession(platformBridge, olcRtcBridge, tunnelBridge)
     }
 
     fun createViewController(
         platformBridge: IosPlatformBridge,
-        olcRtcBridge: IosOlcRtcBridge
+        olcRtcBridge: IosOlcRtcBridge,
+        tunnelBridge: IosTunnelBridge? = null
     ): UIViewController {
-        return createSession(platformBridge, olcRtcBridge).createViewController()
+        return createSession(platformBridge, olcRtcBridge, tunnelBridge).createViewController()
     }
 }
 
 class IosAppSession internal constructor(
     private val platformBridge: IosPlatformBridge,
-    olcRtcBridge: IosOlcRtcBridge
+    olcRtcBridge: IosOlcRtcBridge,
+    tunnelBridge: IosTunnelBridge?
 ) {
-    private val dependencies = IosAppDependencies(platformBridge, olcRtcBridge)
+    private val dependencies = IosAppDependencies(platformBridge, olcRtcBridge, tunnelBridge)
 
     fun createViewController(): UIViewController {
         return ComposeUIViewController {
@@ -75,11 +80,12 @@ class IosAppSession internal constructor(
 
 private class IosAppDependencies(
     platformBridge: IosPlatformBridge,
-    olcRtcBridge: IosOlcRtcBridge
+    olcRtcBridge: IosOlcRtcBridge,
+    tunnelBridge: IosTunnelBridge?
 ) {
     private val locationsDataSource = IosLocationsDataSourceImpl()
     val locationsRepository = LocationsRepositoryImpl(locationsDataSource)
-    val vpnManager = IosVpnManager(locationsRepository, olcRtcBridge)
+    val vpnManager = IosVpnManager(locationsRepository, olcRtcBridge, tunnelBridge)
     val updateService = AppUpdateService(
         deviceIdentityProvider = PersistentDeviceIdentityProvider(locationsDataSource)
     )
@@ -182,7 +188,32 @@ private fun IosApp(
         val logs by dependencies.homeViewModel.logs.collectAsState()
         val homeState by dependencies.homeViewModel.state.collectAsState()
         val socksProxySettings by dependencies.vpnManager.socksProxySettings.collectAsState()
-        val connectionSummary = "SOCKS5 127.0.0.1:${socksProxySettings.port}"
+        val connectionMode by dependencies.vpnManager.connectionMode.collectAsState()
+        val isTun = connectionMode == IosConnectionMode.Tun
+        val connectionSummary = if (isTun) {
+            "VPN · Full tunnel"
+        } else {
+            "SOCKS5 127.0.0.1:${socksProxySettings.port}"
+        }
+        val connectionModeValue = if (isTun) "VPN · Full tunnel" else "Proxy · Local SOCKS5"
+        val connectionModeOptions = if (dependencies.vpnManager.supportsTunMode) {
+            listOf(
+                AppConnectionModeOption(
+                    id = IosConnectionMode.Proxy.value,
+                    title = "Proxy",
+                    subtitle = "Local SOCKS5 endpoint",
+                    selected = !isTun
+                ),
+                AppConnectionModeOption(
+                    id = IosConnectionMode.Tun.value,
+                    title = "VPN",
+                    subtitle = "Full device tunnel",
+                    selected = isTun
+                )
+            )
+        } else {
+            emptyList()
+        }
 
         Box(modifier = Modifier.fillMaxSize()) {
             OlcboxAppContent(
@@ -246,13 +277,29 @@ private fun IosApp(
                     subscriptions = iosSubscriptionItems(dependencies.locationViewModel.locations.toList()),
                     logs = logs,
                     connectionSummary = connectionSummary,
-                    connectionDetails = listOf(
-                        "Mode" to "Local SOCKS5 proxy",
-                        "Host" to "127.0.0.1",
-                        "Port" to socksProxySettings.port.toString()
-                    ),
+                    connectionDetails = if (isTun) {
+                        listOf(
+                            "Mode" to "Full device tunnel",
+                            "Upstream" to "olcRTC SOCKS5 (in-extension)",
+                            "DNS" to "1.1.1.1"
+                        )
+                    } else {
+                        listOf(
+                            "Mode" to "Local SOCKS5 proxy",
+                            "Host" to "127.0.0.1",
+                            "Port" to socksProxySettings.port.toString()
+                        )
+                    },
                     socksProxySettings = socksProxySettings,
                     isConnectionActive = homeState.isVpnConnected,
+                    connectionModeValue = connectionModeValue,
+                    connectionModeOptions = connectionModeOptions,
+                    onConnectionModeSelected = { id ->
+                        dependencies.vpnManager.selectConnectionMode(IosConnectionMode.fromValue(id))
+                        if (homeState.isVpnConnected) {
+                            dependencies.homeViewModel.restartVpnIfRunning()
+                        }
+                    },
                     onDismiss = { isAppSettingsOpen = false },
                     onCopyConfigClick = {
                         dependencies.homeViewModel.onCopyFullConfigClicked()

--- a/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosConnectionMode.kt
+++ b/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosConnectionMode.kt
@@ -1,0 +1,19 @@
+package org.olcbox.app.vpn
+
+/**
+ * iOS connection modes, mirroring Android's `AndroidConnectionMode`.
+ *
+ * - [Proxy]: olcRTC runs in-app and exposes a local SOCKS5 endpoint only. Kept alive
+ *   in the background by the silent-audio hack. Nothing is system-wide.
+ * - [Tun]: a `NEPacketTunnelProvider` extension captures all device traffic and routes
+ *   it through the olcRTC SOCKS5 (hosted inside the extension). A real VPN.
+ */
+enum class IosConnectionMode(val value: String) {
+    Proxy("proxy"),
+    Tun("tun");
+
+    companion object {
+        fun fromValue(value: String?): IosConnectionMode =
+            entries.firstOrNull { it.value == value } ?: Proxy
+    }
+}

--- a/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
+++ b/sharedUI/src/iosMain/kotlin/org/olcbox/app/vpn/IosVpnManager.kt
@@ -22,15 +22,20 @@ import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.repository.LocationsRepository
 import org.olcbox.app.ios.IosBridgeResult
 import org.olcbox.app.ios.IosLogWriter
+import org.olcbox.app.ios.IosMessageCallback
 import org.olcbox.app.ios.IosOlcRtcBridge
 import org.olcbox.app.ios.IosOlcRtcCheckRequest
 import org.olcbox.app.ios.IosOlcRtcStartRequest
+import org.olcbox.app.ios.IosTunnelBridge
+import org.olcbox.app.ios.IosTunnelStartRequest
+import org.olcbox.app.ios.IosTunnelStatusListener
 import org.olcbox.app.ui.components.ApplicationSocksProxySettings
 import platform.Foundation.NSUserDefaults
 
 class IosVpnManager(
     private val locationsRepository: LocationsRepository,
-    private val olcRtcBridge: IosOlcRtcBridge
+    private val olcRtcBridge: IosOlcRtcBridge,
+    private val tunnelBridge: IosTunnelBridge? = null
 ) : VpnManager {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -47,6 +52,18 @@ class IosVpnManager(
 
     private val _socksProxySettings = MutableStateFlow(loadSocksProxySettings())
     val socksProxySettings: StateFlow<ApplicationSocksProxySettings> = _socksProxySettings.asStateFlow()
+
+    // Proxy vs TUN. TUN is only offered when a tunnelBridge is wired (i.e. the app was
+    // built with the PacketTunnel extension). Falls back to Proxy otherwise.
+    private val _connectionMode = MutableStateFlow(loadConnectionMode())
+    val connectionMode: StateFlow<IosConnectionMode> = _connectionMode.asStateFlow()
+
+    /** True on builds that ship the Network Extension (TUN mode is selectable). */
+    val supportsTunMode: Boolean = tunnelBridge != null
+
+    // Which mode the currently-running session was started with, so status callbacks
+    // and stop() route to the right backend.
+    private var activeMode: IosConnectionMode = IosConnectionMode.Proxy
 
     private var operationJob: Job? = null
     private var generation = 0L
@@ -74,14 +91,40 @@ class IosVpnManager(
                     }
             }
         })
+        tunnelBridge?.setStatusListener(object : IosTunnelStatusListener {
+            override fun onStatus(status: String, message: String?) {
+                // Swift delivers this on NotificationCenter's thread; hop into the
+                // manager scope so state changes stay ordered and stop after close().
+                scope.launch { handleTunnelStatus(status, message) }
+            }
+        })
     }
 
     override fun needsPermission(): Boolean = false
+
+    /** Selects Proxy or TUN. Ignored (kept as Proxy) on builds without the extension. */
+    fun selectConnectionMode(mode: IosConnectionMode) {
+        val effective = if (mode == IosConnectionMode.Tun && !supportsTunMode) {
+            IosConnectionMode.Proxy
+        } else {
+            mode
+        }
+        if (_connectionMode.value == effective) return
+        _connectionMode.value = effective
+        saveConnectionMode(effective)
+    }
 
     override fun startVpn() {
         desiredConnected = true
         reconnectAttempt = 0
         reconnectJob?.cancel()
+
+        if (_connectionMode.value == IosConnectionMode.Tun && tunnelBridge != null) {
+            startTunnel()
+            return
+        }
+
+        activeMode = IosConnectionMode.Proxy
         val requestedGeneration = ++generation
         operationJob = scope.launch {
             mutex.withLock {
@@ -109,6 +152,14 @@ class IosVpnManager(
         watchdogJob?.cancel()
         reconnectJob?.cancel()
         generation++
+
+        if (activeMode == IosConnectionMode.Tun && tunnelBridge != null) {
+            setStatus(VpnStatus.Stopping)
+            tunnelBridge.stop()
+            addLog("iOS VPN tunnel stopping")
+            return
+        }
+
         operationJob = scope.launch {
             mutex.withLock {
                 setStatus(VpnStatus.Stopping)
@@ -116,6 +167,70 @@ class IosVpnManager(
                 setStatus(VpnStatus.Disconnected)
                 addLog("iOS SOCKS stopped")
             }
+        }
+    }
+
+    private fun startTunnel() {
+        activeMode = IosConnectionMode.Tun
+        setStatus(VpnStatus.Connecting)
+        scope.launch {
+            val active = locationsRepository.getActiveLocation()
+            val location = active?.location?.normalized()
+            if (location == null || !location.isComplete()) {
+                setStatus(VpnStatus.Error("No active location"))
+                addLog("Add a valid location before starting iOS VPN")
+                return@launch
+            }
+
+            val deviceId = locationsRepository.getDeviceIdentity()
+            val socks = _socksProxySettings.value
+            val request = IosTunnelStartRequest(
+                carrierName = location.bypassProvider,
+                transportName = location.transport,
+                roomId = location.id,
+                clientId = deviceId,
+                keyHex = location.key,
+                socksPort = socks.port,
+                socksUser = socks.username,
+                socksPass = socks.password,
+                vp8Fps = location.vp8Fps,
+                vp8BatchSize = location.vp8Batch,
+                mtu = TUN_MTU,
+                dnsAddress = TUN_DNS_ADDRESS
+            )
+            addLog(
+                "Starting iOS VPN provider=${location.bypassProvider}, " +
+                    "transport=${location.transport}, room=${location.id}"
+            )
+            tunnelBridge?.start(request, object : IosMessageCallback {
+                // NE completion handlers arrive on arbitrary queues; hop into the
+                // manager scope (no-op once close() has cancelled it).
+                override fun onSuccess(message: String) {
+                    scope.launch { addLog("iOS VPN tunnel started") }
+                }
+
+                override fun onError(message: String) {
+                    scope.launch {
+                        setStatus(VpnStatus.Error(message))
+                        addLog("iOS VPN start failed: $message")
+                    }
+                }
+            })
+        }
+    }
+
+    /** Maps NEVPNStatus transitions (reported by the Swift bridge) onto VpnStatus. */
+    private fun handleTunnelStatus(status: String, message: String?) {
+        if (activeMode != IosConnectionMode.Tun) return
+        when (status) {
+            "connected" -> setStatus(VpnStatus.Connected)
+            "connecting" -> setStatus(VpnStatus.Connecting)
+            "reconnecting" -> setStatus(VpnStatus.Reconnecting)
+            "disconnecting" -> setStatus(VpnStatus.Stopping)
+            "disconnected" -> setStatus(
+                if (desiredConnected) VpnStatus.Reconnecting else VpnStatus.Disconnected
+            )
+            "invalid" -> setStatus(VpnStatus.Error(message ?: "VPN configuration invalid"))
         }
     }
 
@@ -153,6 +268,7 @@ class IosVpnManager(
         generation++
         runCatching { olcRtcBridge.setLogWriter(null) }
         runCatching { olcRtcBridge.stop() }
+        runCatching { tunnelBridge?.setStatusListener(null) }
         scope.cancel()
     }
 
@@ -378,6 +494,16 @@ class IosVpnManager(
         defaults.setObject(settings.password, KEY_SOCKS_PASSWORD)
     }
 
+    private fun loadConnectionMode(): IosConnectionMode {
+        if (tunnelBridge == null) return IosConnectionMode.Proxy
+        val stored = NSUserDefaults.standardUserDefaults.stringForKey(KEY_CONNECTION_MODE)
+        return IosConnectionMode.fromValue(stored)
+    }
+
+    private fun saveConnectionMode(mode: IosConnectionMode) {
+        NSUserDefaults.standardUserDefaults.setObject(mode.value, KEY_CONNECTION_MODE)
+    }
+
     private fun sanitizePort(port: Int): Int {
         return if (ApplicationSocksProxySettings.isValidPort(port)) {
             port
@@ -399,6 +525,9 @@ class IosVpnManager(
         const val KEY_SOCKS_PORT = "ios_socks_port"
         const val KEY_SOCKS_USERNAME = "ios_socks_username"
         const val KEY_SOCKS_PASSWORD = "ios_socks_password"
+        const val KEY_CONNECTION_MODE = "ios_connection_mode"
+        const val TUN_MTU = 1500
+        const val TUN_DNS_ADDRESS = "1.1.1.1"
         const val USERNAME_LENGTH = 12
         const val PASSWORD_LENGTH = 24
         const val MAX_CREDENTIAL_LENGTH = 64


### PR DESCRIPTION
## iOS VPN (packet-tunnel) mode

Adds full-device tunnel mode alongside the existing local-SOCKS5 proxy mode,
mirroring Android's TUN path via `NEPacketTunnelProvider`:

```
device packets → utun fd → hev-socks5-tunnel (lwIP tun2socks)
              → 127.0.0.1:socksPort (olcRTC SOCKS5, hosted in-extension)
              → olcRTC WebRTC relay → internet
```

Everything runs inside the extension process, so the tunnel survives app
suspension (no silent-audio keep-alive needed in this mode).

### Notes for review
- The `PacketTunnel` Xcode target is generated by `iosApp/add_packet_tunnel_target.rb`
  (idempotent); the committed pbxproj is one clean run of it.
- The extension pre-build phase builds both native frameworks (hev only when missing).
- One vendored-hev fix: initialise `res` in `hev-socks5-tunnel.c`
  (Xcode 26 clang `-Werror,-Wuninitialized-const-pointer`).
- No Android behaviour change; no olcrtc Go repo change.

### Testing
- On-device (iPhone 17 Pro Max, iOS 26): tunnel connects, VPN icon shows,
  exit IP changes, and the tunnel survives device lock / app suspension.
  Tested under my own team's bundle IDs + app group for provisioning; the
  committed identifiers are unchanged (see docs/ios-vpn-mode.md for the
  App ID / App Group setup a signing team needs).
- Full unsigned `xcodebuild` (app + appex) succeeds, matching the CI/unsigned-IPA flow.
- `:sharedUI:compileKotlinIosArm64` clean (note: CI doesn't compile iosMain).
- `:androidApp:assembleDebug` clean (covers the vendored hev change).

Known risks are listed in `docs/ios-vpn-mode.md` (NE memory budget,
routing-loop protector fallback).