### PR TITLE
fix(android): use OpenDocument for file import and surface read errors

### DIFF
--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/ui/activities/AndroidMainScreen.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/ui/activities/AndroidMainScreen.kt
@@ -281,13 +281,16 @@ fun AndroidMainScreen(
     }
 
     val filePickerLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.GetContent()
+        ActivityResultContracts.OpenDocument()
     ) { uri: Uri? ->
         uri?.let {
             viewModel.onFileSelected(
                 fileSource = it,
                 onComplete = {
                     reloadLocationsAfterImport()
+                },
+                onError = { message ->
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                 }
             )
         }
@@ -356,7 +359,7 @@ fun AndroidMainScreen(
             }
         },
         onImportFileRequested = {
-            filePickerLauncher.launch("*/*")
+            filePickerLauncher.launch(arrayOf("*/*"))
         },
         onImportFromClipboardRequested = { onImported, onError ->
             viewModel.onPasteFromClipboard(


### PR DESCRIPTION
## Summary

Two related bugs in the file-import flow on Android:

1. The file picker used `ActivityResultContracts.GetContent()`, which on some devices/vendors (confirmed on a Xiaomi/HyperOS device) returns a `Uri` that `ContentResolver.openInputStream()` can't actually open — the import then fails silently. `ActivityResultContracts.OpenDocument()` requests a real, persistable document URI and reliably opens on the same device.
2. `onFileSelected` never wired an `onError` callback, so when `readTextFromSource` returned `null` (including the failure above) the user got no feedback at all — the import just silently did nothing.

**Fix:** switch to `OpenDocument()` (requires the MIME-type array overload, `launch(arrayOf("*/*"))`), and wire `onError` to show a `Toast` with the failure message.

## Test plan

- [x] Built and installed on a real Android device (Xiaomi/HyperOS) where `GetContent()` previously failed silently
- [x] Confirmed file import now succeeds on that device
- [x] Confirmed an import failure (e.g. picking something that can't be read) now shows a Toast instead of failing silently