### PR TITLE
Follow a server that moves the client between rooms: dynamic room list, handover refresh, Windows TUN fix, Android IPv6 leak

### DIFF
--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import mobile.Mobile
+import mobile.SessionListener
 import mobile.SocketProtector
 import org.olcbox.app.data.TUN2SOCKS_CONFIG_FILE_NAME
 import org.olcbox.app.data.datasource.LocationsDataSourceImpl
@@ -42,6 +43,7 @@ import org.olcbox.app.data.datasource.LocationsRepositoryImpl
 import org.olcbox.app.data.identity.PersistentDeviceIdentityProvider
 import org.olcbox.app.data.model.LocationConfig
 import org.olcbox.app.data.repository.LocationsRepository
+import org.olcbox.app.data.repository.SubscriptionFetchProxy
 import org.olcbox.app.vpn.AndroidConnectionMode
 import org.olcbox.app.vpn.AndroidSocksProxySettings
 import org.olcbox.app.vpn.AndroidSplitTunnelMode
@@ -95,6 +97,10 @@ class OlcboxVpnService : VpnService() {
     private var watchdogTunStats: Tun2SocksStats? = null
     private var watchdogStalledSamples = 0
     private var lastWakeLockRefreshAtMs = 0L
+    @Volatile
+    private var lastRoomRefreshAtMs = 0L
+    @Volatile
+    private var roomRefreshPendingConnect = false
     @Volatile
     private var lastRtcConnectedAtMs = 0L
     @Volatile
@@ -307,6 +313,74 @@ class OlcboxVpnService : VpnService() {
                 return this@OlcboxVpnService.protect(fd.toInt())
             }
         })
+        olcRtcRuntime.setSessionListener(object : SessionListener {
+            override fun onSessionOpened(room: String, sessionID: String) {
+                onTunnelSessionOpened(room, sessionID)
+            }
+        })
+    }
+
+    // The runtime reports every session it establishes, naming the room. Two of
+    // those moments matter here:
+    //
+    // - A session while we are Connected is a handover: the server retired the
+    //   room we were in and the runtime moved to the standby. Pull the room list
+    //   through the new session at once. Where this runs, the subscription is
+    //   reachable only through the tunnel, and handovers have been observed
+    //   closer together than any periodic refresh - a client with no live room
+    //   left cannot ask for a new one.
+    // - The first session of a generation arrives before the tunnel carries
+    //   traffic (its SOCKS listener opens after it). Remember it and refresh
+    //   once the service reports Connected, so a start or a reconnect on a new
+    //   network begins with a current list even with no UI around to do it.
+    //
+    // This is the mobile counterpart of the desktop client acting on its
+    // "session opened" log line. The shared view model also refreshes on the
+    // Connected transition while it is alive; that fetch is redundant with the
+    // one here and harmless. This one is the one that survives the UI being gone.
+    private fun onTunnelSessionOpened(room: String, sessionID: String) {
+        addLog("olcRTC session $sessionID opened in $room")
+        if (OlcboxVpnState.status.value is VpnStatus.Connected) {
+            refreshRoomsThroughTunnel("handover")
+        } else {
+            roomRefreshPendingConnect = true
+        }
+    }
+
+    private fun refreshRoomsThroughTunnel(reason: String) {
+        val now = System.currentTimeMillis()
+        if (now - lastRoomRefreshAtMs < ROOM_REFRESH_MIN_INTERVAL_MS) return
+        lastRoomRefreshAtMs = now
+        val proxy = SubscriptionFetchProxy(
+            host = socksConnectHost(),
+            port = socksListenPort,
+            username = socksUsername,
+            password = socksPassword
+        )
+        scope.launch {
+            // After a handover the new session's SOCKS listener comes up a
+            // moment after the session itself, and the fetch rides that listener.
+            val socksUp = withContext(Dispatchers.IO) { awaitLocalSocks(proxy.port) }
+            if (!socksUp) {
+                addLog("Room list refresh after $reason skipped: SOCKS not listening")
+                return@launch
+            }
+            runCatching { repository.refreshSubscriptions(subscriptionProxy = proxy) }
+                .onSuccess { addLog("Room list refreshed after $reason ($it updated)") }
+                .onFailure {
+                    // Nothing to recover here: the rotation gate holds the next
+                    // handover until the client has actually received the pair.
+                    addLog("Room list refresh after $reason failed: ${it.message}")
+                }
+        }
+    }
+
+    private suspend fun awaitLocalSocks(port: Int): Boolean {
+        repeat(ROOM_REFRESH_SOCKS_WAIT_STEPS) {
+            if (isLocalSocksPortOpen(port)) return true
+            delay(ROOM_REFRESH_SOCKS_WAIT_STEP_MS)
+        }
+        return false
     }
 
     // Live room-list reload, the mobile counterpart of the desktop client
@@ -1554,6 +1628,10 @@ class OlcboxVpnService : VpnService() {
 
     private fun setStatus(status: VpnStatus) {
         OlcboxVpnState.setStatus(status)
+        if (status is VpnStatus.Connected && roomRefreshPendingConnect) {
+            roomRefreshPendingConnect = false
+            refreshRoomsThroughTunnel("connect")
+        }
     }
 
     private fun activeModeLabel(): String {
@@ -1754,6 +1832,9 @@ class OlcboxVpnService : VpnService() {
         private const val LOCAL_SOCKS_PORT_MAX = 10858
         private const val MOBILE_READY_TIMEOUT_MS = 25_000L
         private const val MOBILE_STOP_TIMEOUT_MS = 5_000L
+        private const val ROOM_REFRESH_MIN_INTERVAL_MS = 15_000L
+        private const val ROOM_REFRESH_SOCKS_WAIT_STEPS = 50
+        private const val ROOM_REFRESH_SOCKS_WAIT_STEP_MS = 100L
         private const val PREVIOUS_STOP_WAIT_MS = 12_000L
         private const val JITSI_RESTART_SETTLE_MS = 2_000L
         private const val TUN2SOCKS_STOP_WAIT_MS = 1_000L

--- a/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
+++ b/sharedUI/src/androidMain/kotlin/org/olcbox/app/vpn/service/OlcboxVpnService.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -252,6 +253,7 @@ class OlcboxVpnService : VpnService() {
             .apply { setReferenceCounted(false) }
 
         installMobileCallbacks()
+        watchRoomListChanges()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -305,6 +307,24 @@ class OlcboxVpnService : VpnService() {
                 return this@OlcboxVpnService.protect(fd.toInt())
             }
         })
+    }
+
+    // Live room-list reload, the mobile counterpart of the desktop client
+    // rewriting its olcRTC config file: when the stored locations change while
+    // a session is running - a subscription refresh delivered a new standby -
+    // hand the runtime the current list. It re-reads that list at its next hop,
+    // so the room the server just advertised is where the client goes when the
+    // one it is in is retired. No restart; the live session is not touched.
+    private fun watchRoomListChanges() {
+        scope.launch {
+            repository.changes.drop(1).collect {
+                if (!olcRtcRuntime.isRunning) return@collect
+                val location = runCatching { repository.getActiveLocation()?.location?.normalized() }
+                    .getOrNull() ?: return@collect
+                if (!location.isComplete()) return@collect
+                applyFailoverRooms(location)
+            }
+        }
     }
 
     private fun loadStartOptions(intent: Intent): StartOptions {
@@ -646,6 +666,7 @@ class OlcboxVpnService : VpnService() {
         olcRtcRuntime.setProvider(config.bypassProvider)
         olcRtcRuntime.setTransport(config.transport)
         olcRtcRuntime.setRoom(config.id)
+        applyFailoverRooms(config)
         olcRtcRuntime.setKey(config.key)
         olcRtcRuntime.setDeviceID(deviceId)
         olcRtcRuntime.setDNS(resolveOlcRtcDnsServer(config.dnsServer))
@@ -653,6 +674,23 @@ class OlcboxVpnService : VpnService() {
         olcRtcRuntime.setSocksPort(socksPort.toLong())
         olcRtcRuntime.setSocksCredentials(socksUsername, socksPassword)
         olcRtcRuntime.setVP8Options(config.vp8Fps.toLong(), config.vp8Batch.toLong())
+    }
+
+    // Hand the runtime every room this location can be reached in, primary
+    // first. The extras arrive in the subscription as `##rooms`; the runtime
+    // moves to the next one when the room it is in is retired, and re-reads the
+    // list at that moment - so this is also what to call when the subscription
+    // refreshes mid-session, not only at start. Without it the client knows one
+    // room, and a server rotating rooms leaves it with nowhere to go.
+    private fun applyFailoverRooms(config: LocationConfig) {
+        olcRtcRuntime.clearFailoverRooms()
+        var applied = 0
+        for (room in config.failoverRoomIds) {
+            runCatching { olcRtcRuntime.addFailoverRoom(room) }
+                .onSuccess { applied++ }
+                .onFailure { addLog("Failover room $room rejected: ${it.message}") }
+        }
+        addLog("olcRTC room list: ${config.failoverRooms().joinToString()} ($applied standby)")
     }
 
     private fun startTun2socks(pfd: ParcelFileDescriptor): Boolean {
@@ -700,6 +738,8 @@ class OlcboxVpnService : VpnService() {
                 .addDnsServer(MAPDNS_ADDRESS)
                 .setBlocking(true)
 
+            applyIpv6Blackhole(builder)
+
             if (!applySplitTunneling(builder)) return null
 
             currentNetwork?.let { builder.setUnderlyingNetworks(arrayOf(it)) }
@@ -709,6 +749,40 @@ class OlcboxVpnService : VpnService() {
             setStatus(VpnStatus.Error(e.message ?: "VPN establish failed"))
             updateNotification("VPN tunnel error")
             null
+        }
+    }
+
+    // The tunnel carries IPv4 only, and Android routes an address family to a VPN
+    // only when that family is configured on it. Leaving IPv6 out therefore does
+    // not disable it - it sends every IPv6 packet around the tunnel, straight out
+    // the physical interface. On a dual-stack mobile network that is both a leak
+    // of the subscriber's real address and a functional break: Happy Eyeballs
+    // prefers IPv6, so sites that resolve to it fail while the tunnel reports a
+    // perfectly good IPv4 exit.
+    //
+    // Pulling IPv6 into the TUN instead makes those packets ours, and the exit
+    // has nowhere to send them - so they die and applications fall back to IPv4
+    // immediately, which is what we want.
+    //
+    // Where exactly they die is worth knowing. The tun2socks config declares no
+    // `ipv6:` address (see writeTun2socksConfig), the intent being that it has no
+    // IPv6 of its own and discards them locally. If it forwards them upstream
+    // anyway, the cost stays bounded: olcRTC refuses IPv6 literals itself once
+    // the exit has reported it has no IPv6 route. Worth confirming on a
+    // dual-stack device by watching whether IPv6 targets reach the tunnel at all.
+    //
+    // Best-effort by design: a device that refuses this configuration keeps a
+    // working IPv4 tunnel instead of no tunnel at all. Nothing persists either -
+    // it lives and dies with the VPN interface.
+    private fun applyIpv6Blackhole(builder: Builder) {
+        if (!BLOCK_IPV6) return
+        runCatching {
+            builder.addAddress(TUN_IPV6_ADDRESS, IPV6_PREFIX_LENGTH)
+            builder.addRoute("::", 0)
+        }.onSuccess {
+            addLog("IPv6 leak protection enabled")
+        }.onFailure {
+            addLog("IPv6 leak protection unavailable (${it.message}) - IPv6 may bypass the tunnel")
         }
     }
 
@@ -785,6 +859,13 @@ class OlcboxVpnService : VpnService() {
         }
     }
 
+    // Note the deliberate absence of an `ipv6:` address below. The VPN interface
+    // does claim one (see applyIpv6Blackhole) so that IPv6 cannot escape around
+    // the tunnel, but this side is left without it on purpose: with no IPv6 of
+    // its own the tunnel discards those packets locally, instead of forwarding
+    // them upstream to an exit that has no IPv6 route and will only answer
+    // "unreachable" after a full round trip. Adding `ipv6:` here would quietly
+    // turn a free drop into paid traffic.
     private fun writeTun2socksConfig(): File {
         val file = File(filesDir, TUN2SOCKS_CONFIG_FILE_NAME)
 
@@ -1702,6 +1783,18 @@ class OlcboxVpnService : VpnService() {
         private const val TUN_TCP_BUFFER_SIZE = 65_536
         private const val TUN_TASK_STACK_SIZE = 86_016
         private const val IPV4_PREFIX_LENGTH = 24
+
+        // A unique-local address, so nothing routable is claimed. Matches the
+        // desktop client's blackhole address for the same reason: whoever reads
+        // one of the two logs should recognise the other.
+        private const val TUN_IPV6_ADDRESS = "fd00:88::1"
+        private const val IPV6_PREFIX_LENGTH = 64
+
+        // On by default, as on desktop. A constant rather than a setting because
+        // there is no supported configuration in which leaking IPv6 around the
+        // tunnel is what the user wanted; kept named so a future toggle has an
+        // obvious home. See applyIpv6Blackhole.
+        private const val BLOCK_IPV6 = true
         private const val DEFAULT_OLCRTC_DNS_SERVER = "1.1.1.1:53"
         private const val MAPDNS_ADDRESS = "1.1.1.1"
         private const val MAPDNS_NETWORK = "100.64.0.0"

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/datasource/LocationsDatasource.kt
@@ -1257,7 +1257,8 @@ class LocationsRepositoryImpl(
                     metadata?.name,
                     parsed.mimo,
                     parsed.location.name
-                )
+                ),
+                failoverRoomIds = parseFailoverRooms(fields["rooms"])
             ).normalized()
             val base = location.storageSlug().ifBlank { "location_${index + 1}" }
             val storageId = uniqueStorageId("imported_$base", usedStorageIds)
@@ -1355,6 +1356,15 @@ class LocationsRepositoryImpl(
             mimo = mimo,
             subscription = subscription
         ).normalized().takeUnless { it.isEmpty() }
+    }
+
+    // Extra failover room ids delivered via a `##rooms:` header (comma/space
+    // separated). They share the location's key/provider/transport.
+    private fun parseFailoverRooms(value: String?): List<String> {
+        if (value.isNullOrBlank()) return emptyList()
+        return value.split(',', ' ', '\t', '\n')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
     }
 
     private fun parseTransportToken(token: String): Pair<String, Map<String, Int>> {

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/data/model/LocationConfig.kt
@@ -29,7 +29,12 @@ data class LocationConfig(
     @SerialName("vp8_batch")
     val vp8Batch: Int = DEFAULT_VP8_BATCH,
     @SerialName("dns_server")
-    val dnsServer: String = ""
+    val dnsServer: String = "",
+    // Extra room ids that, together with `id`, form one failover group sharing
+    // this location's key/provider/transport. When non-empty the client runs a
+    // failover config so it hops between rooms in-process (dynamic room list).
+    @SerialName("failover_rooms")
+    val failoverRoomIds: List<String> = emptyList()
 ) {
     fun normalized(): LocationConfig {
         val provider = normalizeProvider(bypassProvider)
@@ -42,9 +47,19 @@ data class LocationConfig(
             transport = normalizedTransport,
             dnsServer = dnsServer.trim().take(MAX_DNS_SERVER_LENGTH),
             vp8Fps = sanitizeVp8Fps(vp8Fps),
-            vp8Batch = sanitizeVp8Batch(vp8Batch)
+            vp8Batch = sanitizeVp8Batch(vp8Batch),
+            failoverRoomIds = failoverRoomIds
+                .map { it.trim() }
+                .filter { it.isNotBlank() && it != id.trim() }
+                .distinct()
         )
     }
+
+    /** Ordered room list for a failover config: the primary room, then extras. */
+    fun failoverRooms(): List<String> = (listOf(id) + failoverRoomIds)
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .distinct()
 
     fun isComplete(): Boolean = id.isNotBlank() && key.isNotBlank()
 
@@ -411,7 +426,11 @@ data class SubscriptionMetadata(
         const val MAX_UPDATE_INTERVAL_HOURS = 720
         const val MIN_UPDATE_INTERVAL_MS = 5L * 60L * 1_000L
         const val DEFAULT_UPDATE_INTERVAL_MS = DEFAULT_UPDATE_INTERVAL_HOURS * 60L * 60L * 1_000L
-        const val MAX_UPDATE_INTERVAL_MS = MAX_UPDATE_INTERVAL_HOURS * 60L * 60L * 1_000L
+        // olcWave seamless rotation: cap the effective auto-refresh interval at 2h
+        // (min stays 5m) so the client always polls often enough to receive the next
+        // room before the current one is torn down. Applies to both the server-sent
+        // #refresh value and any manual override (both coerced into this range).
+        const val MAX_UPDATE_INTERVAL_MS = 120L * 60L * 1_000L
         const val HOUR_MS = 60L * 60L * 1_000L
         private const val RETRY_BASE_MS = 5L * 60L * 1_000L
         private const val RETRY_MAX_MS = 6L * HOUR_MS
@@ -520,6 +539,12 @@ data class LocationEntry(
     @SerialName("subscription_url")
     val subscriptionUrl: String? = null,
     val endpoint: LocationEndpointConfig? = null,
+    // Extra rooms of this location's failover group, delivered by the
+    // subscription as `##rooms`. Without a home here the parsed list was dropped
+    // the moment an entry was saved, so the client only ever knew its primary
+    // room and a rotation had nowhere to hand it over to.
+    @SerialName("failover_rooms")
+    val failoverRooms: List<String> = emptyList(),
     @SerialName("auth_provider")
     val authProvider: String? = null,
     @SerialName("carrier")
@@ -588,7 +613,8 @@ data class LocationEntry(
                     ?: legacyVp8Batch
                     ?: legacyVp8BatchCamel
                     ?: LocationConfig.DEFAULT_VP8_BATCH,
-                dnsServer = firstNotBlank(dnsServer, legacyDnsServerCamel)
+                dnsServer = firstNotBlank(dnsServer, legacyDnsServerCamel),
+                failoverRoomIds = failoverRooms
             ).normalized()
         }
 
@@ -605,6 +631,7 @@ data class LocationEntry(
                 roomId = config.id,
                 key = config.key
             ),
+            failoverRooms = config.failoverRoomIds,
             authProvider = config.bypassProvider,
             transport = LocationTransportConfig.from(config),
             dnsServer = config.dnsServer.takeIf { it.isNotBlank() },
@@ -630,6 +657,7 @@ data class LocationEntry(
                     roomId = config.id,
                     key = config.key
                 ),
+                failoverRooms = config.failoverRoomIds,
                 authProvider = config.bypassProvider,
                 transport = LocationTransportConfig.from(config),
                 dnsServer = config.dnsServer.takeIf { it.isNotBlank() },

--- a/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreenModel.kt
+++ b/sharedUI/src/commonMain/kotlin/org/olcbox/app/ui/features/home/HomeScreenModel.kt
@@ -59,6 +59,7 @@ class HomeScreenViewModel(
         }
 
         viewModelScope.launch {
+            var wasConnected = false
             vpnManager.status.collect { status ->
                 _state.update {
                     when (status) {
@@ -70,6 +71,22 @@ class HomeScreenViewModel(
                         is VpnStatus.Error -> it.copy(isVpnConnected = false, isVpnLoading = false)
                     }
                 }
+
+                // Tunnel just came up: immediately pull the freshest rooms through it,
+                // so the session begins with current rooms (and tops up if we connected
+                // on an about-to-expire one). The fetch rides the live tunnel's SOCKS.
+                val nowConnected = status is VpnStatus.Connected
+                if (nowConnected && !wasConnected) {
+                    viewModelScope.launch {
+                        runCatching {
+                            locationsRepository.refreshSubscriptions(
+                                subscriptionProxy = vpnManager.subscriptionFetchProxy()
+                            )
+                        }
+                        loadCurrentConfigNow()
+                    }
+                }
+                wasConnected = nowConnected
             }
         }
     }
@@ -147,6 +164,16 @@ class HomeScreenViewModel(
             _state.update { it.copy(isVpnLoading = true) }
             try {
                 if (_state.value.isVpnConnected || vpnManager.status.value is VpnStatus.Connected) {
+                    // Pull the freshest rooms through the still-live tunnel before we
+                    // tear it down, so the next start begins current. Bounded so Stop
+                    // never hangs if the tunnel is already dying.
+                    withTimeoutOrNull(PRE_DISCONNECT_REFRESH_TIMEOUT_MS) {
+                        runCatching {
+                            locationsRepository.refreshSubscriptions(
+                                subscriptionProxy = vpnManager.subscriptionFetchProxy()
+                            )
+                        }
+                    }
                     vpnManager.stopVpn()
                 } else {
                     val active = locationsRepository.getActiveLocation()
@@ -437,3 +464,4 @@ data class HomeScreenState(
 
 private const val MIN_SUBSCRIPTION_REFRESH_WAIT_MS = 1_000L
 private const val IDLE_SUBSCRIPTION_REFRESH_WAIT_MS = 24L * 60L * 60L * 1_000L
+private const val PRE_DISCONNECT_REFRESH_TIMEOUT_MS = 4_000L

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/DesktopVpnManager.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -36,6 +37,7 @@ import java.net.Socket
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.TimeUnit
 
 class DesktopVpnManager private constructor(
@@ -73,10 +75,26 @@ class DesktopVpnManager private constructor(
     private var process: Process? = null
     private var tunProcess: Process? = null
     private var olcRtcConfigPath: Path? = null
+    private var olcRtcBinary: Path? = null
     private var activeDesktopMode: DesktopMode? = null
     private var generation = 0L
+    // Rate limit for the post-handover room refresh, so a client cycling through
+    // dead rooms cannot turn one fetch per hop into a storm.
+    @Volatile
+    private var lastSwitchRefreshAt = 0L
     private val linuxTunController = LinuxTunController(::addLog)
     private val windowsTunController = WindowsTunController(::addLog)
+
+    init {
+        // Live room-list reload: when the subscription changes while connected,
+        // rewrite the olcRTC config file in place. In failover mode olcRTC re-reads
+        // it on its next room hop, so new rooms are picked up WITHOUT a restart.
+        scope.launch {
+            locationsRepository.changes
+                .drop(1)
+                .collect { rewriteActiveConfigIfConnected() }
+        }
+    }
 
     override fun needsPermission(): Boolean = false
 
@@ -206,13 +224,21 @@ class DesktopVpnManager private constructor(
                 windowsTunController.ensureAdministratorOrRequestRestart()
             }
 
+            // Read before the TUN exists, so it is the machine's real path out.
+            val bindInterfaceIndex = if (desktopMode == DesktopMode.WindowsTun) {
+                windowsTunController.defaultRouteInterfaceIndex()
+            } else {
+                null
+            }
+
             process = startOlcRtcProcessWithFallback(
                 location = location,
                 socksSettings = socksSettings,
                 ready = ready,
                 startupFailure = startupFailure,
                 logOutput = true,
-                privileged = desktopMode == DesktopMode.LinuxTun
+                privileged = desktopMode == DesktopMode.LinuxTun,
+                bindInterfaceIndex = bindInterfaceIndex
             )
 
             val olcRtcProcess = process ?: error("olcRTC process is missing")
@@ -338,7 +364,8 @@ class DesktopVpnManager private constructor(
         ready: CompletableDeferred<Unit>,
         startupFailure: CompletableDeferred<String>,
         logOutput: Boolean,
-        privileged: Boolean
+        privileged: Boolean,
+        bindInterfaceIndex: Int?
     ): Process {
         val binaries = DesktopNativeAssets.resolveOlcRtcBinaryCandidates()
         val dnsServer = location.dnsServer.ifBlank { DesktopDnsResolver.current() }
@@ -356,6 +383,7 @@ class DesktopVpnManager private constructor(
                     startupFailure = startupFailure,
                     logOutput = logOutput,
                     privileged = privileged,
+                    bindInterfaceIndex = bindInterfaceIndex,
                     dnsServer = dnsServer
                 )
             } catch (e: Exception) {
@@ -453,6 +481,7 @@ class DesktopVpnManager private constructor(
         startupFailure: CompletableDeferred<String>,
         logOutput: Boolean,
         privileged: Boolean,
+        bindInterfaceIndex: Int?,
         dnsServer: String
     ): Process {
         val config = location.normalized()
@@ -482,6 +511,17 @@ class DesktopVpnManager private constructor(
         processBuilder.environment()["NO_PROXY"] = "127.0.0.1,localhost"
         processBuilder.environment()["no_proxy"] = "127.0.0.1,localhost"
 
+        // Windows has no VpnService.protect. Pinning olcRTC's own sockets to the
+        // physical interface is what keeps its provider calls off the TUN, so it
+        // can still reach a conference to join a new room after the tunnel it
+        // would otherwise have used is gone.
+        if (bindInterfaceIndex != null) {
+            processBuilder.environment()[OLCRTC_BIND_IFINDEX_ENV] = bindInterfaceIndex.toString()
+            addLog("olcRTC sockets pinned to interface index $bindInterfaceIndex (keeps its own traffic off the TUN)")
+        } else if (activeDesktopMode == DesktopMode.WindowsTun) {
+            addLog("Could not determine the physical interface index - olcRTC traffic may follow the TUN route")
+        }
+
         val startedProcess = try {
             processBuilder.start()
         } catch (e: Exception) {
@@ -508,6 +548,10 @@ class DesktopVpnManager private constructor(
                             ready.complete(Unit)
                         }
 
+                        if (isSessionOpenedLine(line)) {
+                            refreshRoomsAfterSwitch()
+                        }
+
                         if (isFatalOlcRtcStartupLine(line)) {
                             startupFailure.complete(line)
                         }
@@ -523,7 +567,98 @@ class DesktopVpnManager private constructor(
             logJob = readerJob
         }
 
+        olcRtcBinary = binary
+
         return startedProcess
+    }
+
+    // Rewrites the running olcRTC config file with the current active location's
+    // rooms. Only acts while connected and only for failover (multi-room)
+    // locations, since single-room olcRTC does not reload. olcRTC picks the new
+    // list up on its next hop - no process restart, live session untouched.
+    private suspend fun rewriteActiveConfigIfConnected() {
+        mutex.withLock {
+            val path = olcRtcConfigPath ?: return
+            val binary = olcRtcBinary ?: return
+
+            val currentStatus = _status.value
+            if (currentStatus !is VpnStatus.Connected &&
+                currentStatus !is VpnStatus.Reconnecting
+            ) {
+                return
+            }
+
+            val active = locationsRepository.getActiveLocation()?.location?.normalized() ?: return
+
+            val socksSettings = _socksProxySettings.value.normalized()
+            val dnsServer = active.dnsServer.ifBlank { DesktopDnsResolver.current() }
+            val command = OlcRtcCommand(
+                binary = binary,
+                location = active,
+                socksHost = socksSettings.host,
+                socksPort = socksSettings.port,
+                socksUser = socksSettings.username,
+                socksPass = socksSettings.password,
+                dnsServer = dnsServer
+            )
+
+            runCatching {
+                val tmp = Files.createTempFile(path.parent, "olcrtc-reload-", ".yaml")
+                Files.writeString(tmp, command.yaml(), StandardCharsets.UTF_8)
+                Files.move(
+                    tmp,
+                    path,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING
+                )
+            }.onSuccess {
+                // List the ids, not just the count: a rotation only works when the
+                // standby the server advertised is actually in here, and a bare
+                // count cannot tell "the standby is missing" from "there is one".
+                val rooms = active.failoverRooms()
+                addLog(
+                    "olcRTC room list refreshed (${rooms.size} rooms: ${rooms.joinToString()}) " +
+                        "- live reload, no restart"
+                )
+            }.onFailure {
+                addLog("olcRTC live config reload failed: ${it.message}")
+            }
+        }
+    }
+
+    // olcRTC has just established a session - on a new room, if this followed a
+    // handover. Pull the room list through the tunnel NOW rather than waiting for
+    // the periodic refresh.
+    //
+    // Why it matters: the server retires the old room as soon as the client is
+    // safely on the new one, so between a handover and the next scheduled fetch
+    // the client's list holds exactly ONE live room. That window was minutes, and
+    // handovers have been observed 95 seconds apart - closer together than the
+    // refresh interval, which no amount of waiting can survive. On a whitelist a
+    // client with no live room left cannot ask for a new one: the request would
+    // have to travel through the tunnel it just lost.
+    private fun refreshRoomsAfterSwitch() {
+        // Only meaningful once the tunnel carries traffic: the fetch rides its
+        // SOCKS. The first session of a connection lands here while we are still
+        // Connecting, and is covered by the refresh on the Connected transition.
+        if (_status.value !is VpnStatus.Connected) return
+
+        val now = System.currentTimeMillis()
+        if (now - lastSwitchRefreshAt < SWITCH_REFRESH_MIN_INTERVAL_MS) return
+        lastSwitchRefreshAt = now
+
+        scope.launch {
+            runCatching {
+                locationsRepository.refreshSubscriptions(
+                    subscriptionProxy = subscriptionFetchProxy()
+                )
+            }.onFailure {
+                // Nothing to recover here - the periodic refresh is still running,
+                // and the rotation gate holds the next handover until the client
+                // has actually received the pair.
+                addLog("Room list refresh after handover failed: ${it.message}")
+            }
+        }
     }
 
     private fun writeOlcRtcClientConfig(command: OlcRtcCommand): Path {
@@ -633,9 +768,64 @@ class DesktopVpnManager private constructor(
         addLog(logMessage)
         stopDesktopMode(finalStatus = false)
 
-        if (requestGeneration == generation) {
-            setStatus(VpnStatus.Error(errorMessage))
+        // A user start/stop bumps `generation` up front; if that already happened,
+        // this dead connection is superseded and we must not touch anything.
+        if (requestGeneration != generation) return
+
+        // Auto-reconnect. On a whitelist we cannot fetch a fresh subscription without
+        // a live tunnel, so we simply relaunch onto the STORED active location (kept
+        // current by the background refresh while a tunnel was up). No network here.
+        //
+        // This retries indefinitely, on purpose. Giving up used to leave the app in
+        // Error after about two minutes, which is shorter than a laptop waking, a
+        // Wi-Fi roam or a provider hiccup - and on a whitelist there is no other way
+        // back: reconnecting IS the only path to a working tunnel, and a working
+        // tunnel is the only path to a fresh room list. A capped backoff makes an
+        // endless retry cheap; the user can still stop it, which bumps `generation`
+        // and drops us out on the next check.
+        addLog("Connection lost ($errorMessage) - reconnecting until it comes back")
+
+        var expectedGeneration = requestGeneration
+        var attempt = 0
+        while (true) {
+            attempt++
+            setStatus(VpnStatus.Reconnecting)
+            val backoff = reconnectBackoffMs(attempt)
+            if (attempt <= RECONNECT_VERBOSE_ATTEMPTS || attempt % RECONNECT_LOG_EVERY == 0) {
+                addLog("Auto-reconnect attempt $attempt in ${backoff / 1000}s")
+            }
+
+            reconnectBackoffDelay(backoff, expectedGeneration)
+            if (generation != expectedGeneration) return  // a user action superseded us
+
+            val attemptGeneration = ++generation
+            expectedGeneration = attemptGeneration
+            startDesktopMode(attemptGeneration, isRestart = true)
+
+            if (generation != attemptGeneration) return   // user acted during the attempt
+            if (_status.value is VpnStatus.Connected) {
+                addLog("Auto-reconnect succeeded on attempt $attempt")
+                return
+            }
+            // attempt failed with no user action -> loop and retry
         }
+    }
+
+    /** Interruptible backoff: bails early the moment a user action bumps generation. */
+    private suspend fun reconnectBackoffDelay(totalMs: Long, expectedGeneration: Long) {
+        var waited = 0L
+        while (waited < totalMs) {
+            if (generation != expectedGeneration) return
+            val step = minOf(RECONNECT_BACKOFF_POLL_MS, totalMs - waited)
+            delay(step)
+            waited += step
+        }
+    }
+
+    private fun reconnectBackoffMs(attempt: Int): Long {
+        val shift = (attempt - 1).coerceIn(0, 4)
+        return (RECONNECT_BASE_BACKOFF_MS * (1L shl shift))
+            .coerceAtMost(RECONNECT_MAX_BACKOFF_MS)
     }
 
     private fun waitForProcessExit(target: Process): Int? {
@@ -755,6 +945,22 @@ class DesktopVpnManager private constructor(
         const val PROCESS_KILL_TIMEOUT_MS = 1_000L
         const val DEFAULT_LOCATION_PING_PARALLELISM = 4
 
+        // Read by olcRTC's protect package; must match protect.BindInterfaceEnv.
+        const val OLCRTC_BIND_IFINDEX_ENV = "OLCRTC_BIND_IFINDEX"
+
+        // Desktop auto-reconnect on unexpected olcRTC/TUN exit (whitelist-safe:
+        // relaunch onto the stored active location, no network fetch).
+        // Auto-reconnect never gives up (see reconnect loop), so the attempt log
+        // is throttled: every attempt at first, then occasionally, so a long
+        // outage leaves a trail without burying everything else in the log.
+        const val RECONNECT_VERBOSE_ATTEMPTS = 6
+        const val RECONNECT_LOG_EVERY = 20
+        const val RECONNECT_BASE_BACKOFF_MS = 2_000L
+        const val RECONNECT_MAX_BACKOFF_MS = 20_000L
+        const val RECONNECT_BACKOFF_POLL_MS = 250L
+
+        const val SWITCH_REFRESH_MIN_INTERVAL_MS = 15_000L
+
         internal fun isFatalOlcRtcStartupLine(line: String): Boolean {
             val text = line.lowercase()
             return "failed to connect link" in text ||
@@ -763,4 +969,17 @@ class DesktopVpnManager private constructor(
                     "transport connect" in text && "failed" in text
         }
     }
+}
+
+/**
+ * olcRTC logs this once a tunnel session is established - including the new
+ * session it opens after a room handover, which is the moment the client can
+ * safely go and fetch the room list through the tunnel again.
+ *
+ * Top-level rather than in the companion so it stays reachable from tests
+ * without widening the visibility of everything else in there.
+ */
+internal fun isSessionOpenedLine(line: String): Boolean {
+    val text = line.lowercase()
+    return "session " in text && " opened (device=" in text
 }

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/OlcRtcCommand.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/OlcRtcCommand.kt
@@ -20,13 +20,17 @@ internal data class OlcRtcCommand(
     fun yaml(): String {
         val config = location.normalized()
         val provider = desktopProviderArg(config.bypassProvider)
+        // Always emit a failover `profiles:` config (even for a single room) so
+        // olcRTC runs under the supervisor and re-reads this file on every hop.
+        // That is what makes the room list DYNAMIC: rooms added later (##rooms)
+        // are picked up live, no restart. A single-room location is just a
+        // one-profile supervisor that reconnects in place instead of exiting.
+        val rooms = config.failoverRooms()
 
         return buildString {
             appendLine("mode: cnc")
             appendLine("auth:")
             appendLine("  provider: ${provider.yamlValue()}")
-            appendLine("room:")
-            appendLine("  id: ${config.id.yamlValue()}")
             appendLine("crypto:")
             appendLine("  key: ${config.key.yamlValue()}")
             appendLine("net:")
@@ -54,6 +58,18 @@ internal data class OlcRtcCommand(
                 }
             }
             dataDir?.let { appendLine("data: ${it.toString().yamlValue()}") }
+            appendLine("liveness:")
+            appendLine("  interval: 5s")
+            appendLine("  timeout: 8s")
+            appendLine("  failures: 2")
+            appendLine("profiles:")
+            rooms.forEach { room ->
+                appendLine("  - name: ${room.yamlValue()}")
+                appendLine("    room:")
+                appendLine("      id: ${room.yamlValue()}")
+            }
+            appendLine("failover:")
+            appendLine("  retry_delay: 2s")
         }
     }
 

--- a/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/WindowsTunController.kt
+++ b/sharedUI/src/jvmMain/kotlin/org/olcbox/app/vpn/desktop/WindowsTunController.kt
@@ -8,7 +8,8 @@ import java.util.concurrent.TimeUnit
 import kotlin.system.exitProcess
 
 internal class WindowsTunController(
-    private val addLog: (String) -> Unit
+    private val addLog: (String) -> Unit,
+    private val blockIpv6: Boolean = true
 ) {
     private var routesInstalled = false
 
@@ -26,6 +27,12 @@ internal class WindowsTunController(
         try {
             waitForAdapter(process)
             installRoutes()
+            if (blockIpv6) {
+                runCatching { installIpv6Blackhole() }
+                    .onFailure {
+                        addLog("Windows TUN IPv6 leak protection failed, continuing IPv4-only: ${it.message}")
+                    }
+            }
             routesInstalled = true
             addLog("Windows TUN connected on $TUN_NAME")
             return process
@@ -143,6 +150,39 @@ internal class WindowsTunController(
         )
     }
 
+    // Drops all IPv6 into the TUN while connected so dual-stack traffic can't leak
+    // around the IPv4-only tunnel, and apps fall back to IPv4 via Happy Eyeballs.
+    // Note tun2socks does not discard the captured IPv6 itself - SOCKS5 carries v6
+    // addresses fine, so it forwards them upstream. olcrtc is what refuses them, and
+    // it does so locally once the exit has reported it has no IPv6 route; otherwise
+    // every blackholed connection would burn a tunnel stream and a round trip on an
+    // address family that can never be reached.
+    // Best-effort: never breaks the IPv4 tunnel.
+    private suspend fun installIpv6Blackhole() {
+        runPowerShell(
+            """
+            ${'$'}ErrorActionPreference = 'Stop'
+            ${'$'}adapter = Get-NetAdapter -Name '$TUN_NAME' -ErrorAction Stop
+            ${'$'}ifIndex = ${'$'}adapter.ifIndex
+
+            Get-NetIPAddress -InterfaceIndex ${'$'}ifIndex -AddressFamily IPv6 -ErrorAction SilentlyContinue |
+              Where-Object { ${'$'}_.IPAddress -eq '$TUN_IPV6_ADDRESS' } |
+              Remove-NetIPAddress -Confirm:${'$'}false -ErrorAction SilentlyContinue
+
+            New-NetIPAddress -InterfaceIndex ${'$'}ifIndex -IPAddress '$TUN_IPV6_ADDRESS' -PrefixLength $TUN_IPV6_PREFIX_LENGTH -AddressFamily IPv6 | Out-Null
+
+            Get-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '::/1' -ErrorAction SilentlyContinue |
+              Remove-NetRoute -Confirm:${'$'}false -ErrorAction SilentlyContinue
+            Get-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '8000::/1' -ErrorAction SilentlyContinue |
+              Remove-NetRoute -Confirm:${'$'}false -ErrorAction SilentlyContinue
+
+            New-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '::/1' -NextHop '::' -RouteMetric 1 | Out-Null
+            New-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '8000::/1' -NextHop '::' -RouteMetric 1 | Out-Null
+            """.trimIndent()
+        )
+        addLog("Windows TUN IPv6 leak protection enabled")
+    }
+
     private suspend fun removeRoutes() {
         runPowerShell(
             """
@@ -153,6 +193,13 @@ internal class WindowsTunController(
               Remove-NetRoute -Confirm:${'$'}false -ErrorAction SilentlyContinue
             Get-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '128.0.0.0/1' -ErrorAction SilentlyContinue |
               Remove-NetRoute -Confirm:${'$'}false -ErrorAction SilentlyContinue
+            Get-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '::/1' -ErrorAction SilentlyContinue |
+              Remove-NetRoute -Confirm:${'$'}false -ErrorAction SilentlyContinue
+            Get-NetRoute -InterfaceIndex ${'$'}ifIndex -DestinationPrefix '8000::/1' -ErrorAction SilentlyContinue |
+              Remove-NetRoute -Confirm:${'$'}false -ErrorAction SilentlyContinue
+            Get-NetIPAddress -InterfaceIndex ${'$'}ifIndex -AddressFamily IPv6 -ErrorAction SilentlyContinue |
+              Where-Object { ${'$'}_.IPAddress -eq '$TUN_IPV6_ADDRESS' } |
+              Remove-NetIPAddress -Confirm:${'$'}false -ErrorAction SilentlyContinue
             Set-DnsClientServerAddress -InterfaceIndex ${'$'}ifIndex -ResetServerAddresses -ErrorAction SilentlyContinue
             Get-NetIPAddress -InterfaceIndex ${'$'}ifIndex -AddressFamily IPv4 -ErrorAction SilentlyContinue |
               Where-Object { ${'$'}_.IPAddress -eq '$TUN_IPV4_ADDRESS' } |
@@ -160,6 +207,32 @@ internal class WindowsTunController(
             """.trimIndent()
         )
     }
+
+    // Index of the interface the machine reaches the internet through, ignoring
+    // our own TUN. olcRTC is told to pin its own sockets to it, so the calls it
+    // makes to reach a conference keep working after the TUN owns the default
+    // route - otherwise re-joining a room needs the tunnel that re-joining is
+    // supposed to restore. Blocking on purpose: it has to be known before olcRTC
+    // starts, which is before the TUN exists. Null means "leave the route table
+    // alone", which is the pre-existing behaviour.
+    fun defaultRouteInterfaceIndex(): Int? = runCatching {
+        val process = ProcessBuilder(
+            "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
+            """
+            ${'$'}ErrorActionPreference = 'SilentlyContinue'
+            Get-NetRoute -DestinationPrefix '0.0.0.0/0' |
+              Where-Object { ${'$'}_.InterfaceAlias -ne '$TUN_NAME' } |
+              Sort-Object RouteMetric |
+              Select-Object -First 1 -ExpandProperty ifIndex
+            """.trimIndent()
+        ).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        if (!process.waitFor(POWERSHELL_QUERY_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly()
+            return@runCatching null
+        }
+        output.trim().lineSequence().firstOrNull { it.isNotBlank() }?.trim()?.toIntOrNull()
+    }.getOrNull()
 
     private suspend fun runPowerShell(script: String): String = withContext(Dispatchers.IO) {
         val process = ProcessBuilder(
@@ -196,9 +269,12 @@ internal class WindowsTunController(
         const val TUN_MTU = 1500
         const val TUN_IPV4_ADDRESS = "10.0.88.88"
         const val TUN_IPV4_PREFIX_LENGTH = 24
+        const val TUN_IPV6_ADDRESS = "fd00:88::1"
+        const val TUN_IPV6_PREFIX_LENGTH = 64
         const val MAPDNS_ADDRESS = "1.1.1.1"
         const val TUN_READY_TIMEOUT_MS = 10_000L
         const val TUN_READY_POLL_MS = 100L
+        const val POWERSHELL_QUERY_TIMEOUT_MS = 5_000L
         const val PROCESS_STOP_TIMEOUT_MS = 3_000L
         const val PROCESS_KILL_TIMEOUT_MS = 1_000L
         const val ELEVATED_START_ARGUMENT = "--olcbox-start-vpn-after-elevation"
@@ -214,8 +290,13 @@ internal class WindowsTunController(
             "socks5://${PacServer.LOCAL_SOCKS_HOST}:$socksPort",
             "--mtu",
             TUN_MTU.toString(),
+            // "error", not "warn": tun2socks logs one warn per failed dial, and the
+            // blackholed IPv6 plus the UDP the tunnel cannot carry produce tens of
+            // those per second. At warn they overran the in-app log ring in under a
+            // minute, evicting the tunnel events the log exists to capture. olcrtc
+            // logs its own side of every connection, which is the useful half.
             "--loglevel",
-            "warn"
+            "error"
         )
 
         fun restartAsAdministratorScript(

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/data/datasource/JvmLocationsDataSourceImplTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/data/datasource/JvmLocationsDataSourceImplTest.kt
@@ -42,4 +42,40 @@ class JvmLocationsDataSourceImplTest {
 
         assertEquals("install-test", source.loadDeviceIdentity())
     }
+
+    @Test
+    fun keepsFailoverRoomsAcrossASaveAndLoad() = runTest {
+        val dir = Files.createTempDirectory("olcbox-failover-rooms-test")
+        val source = JvmLocationsDataSourceImpl(dir)
+        val bundle = LocationBundleV4(
+            activeLocationId = "desk",
+            locations = listOf(
+                LocationEntry.from(
+                    "desk",
+                    LocationConfig(
+                        name = "Desktop",
+                        id = "11115586048655",
+                        key = "a".repeat(64),
+                        bypassProvider = LocationConfig.PROVIDER_TELEMOST,
+                        failoverRoomIds = listOf("81055221156696")
+                    )
+                )
+            )
+        )
+
+        source.saveLocationBundle(bundle)
+
+        // The standby room has to survive storage: it is the only thing the client
+        // can hand itself over to when the server retires the primary room.
+        val loaded = source.loadLocationBundle()
+        assertNotNull(loaded)
+        assertEquals(
+            listOf("81055221156696"),
+            loaded.locations.first().location.failoverRoomIds
+        )
+        assertEquals(
+            listOf("11115586048655", "81055221156696"),
+            loaded.locations.first().location.failoverRooms()
+        )
+    }
 }

--- a/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/DesktopVpnManagerLogParsingTest.kt
+++ b/sharedUI/src/jvmTest/kotlin/org/olcbox/app/vpn/DesktopVpnManagerLogParsingTest.kt
@@ -1,0 +1,37 @@
+package org.olcbox.app.vpn
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The room list is refreshed off this line, and on a whitelist that refresh is
+ * the only thing standing between a handover and a client whose stored rooms
+ * have all been retired. Worth pinning to real olcRTC output.
+ */
+class DesktopVpnManagerLogParsingTest {
+
+    @Test
+    fun recognisesTheSessionOpenedLineOlcRtcActuallyPrints() {
+        assertTrue(
+            isSessionOpenedLine(
+                "2026/08/28 22:06:57 session 4238c0b2-46e3-4234-b7ac-a90284ee079f " +
+                    "opened (device=ffb3ad78-e7e5-4342-ade1-ffdfbbf7bc33)"
+            )
+        )
+    }
+
+    @Test
+    fun ignoresNeighbouringLinesThatAlsoMentionSessions() {
+        val notASessionOpen = listOf(
+            "2026/08/28 22:06:53 control stream ended role=client session=e19b11d8: control stream closed by peer",
+            "2026/08/28 22:06:53 client reconnect reason=liveness - tearing down smux session",
+            "2026/08/28 22:06:55 failover cycle=1 starting profile=81055221156696 provider=telemost",
+            "2026/08/28 22:06:57 SOCKS5 server listening on 127.0.0.1:10808",
+            "2026/08/28 22:06:57 session closed: id=4238c0b2 reason=closed",
+        )
+        for (line in notASessionOpen) {
+            assertFalse(isSessionOpenedLine(line), line)
+        }
+    }
+}


### PR DESCRIPTION
Six commits, each carrying its own full description. They come from running olcbox against a server that continuously moves the client between short-lived conference rooms (the rooms expire after about a day), on networks where only the conference provider is reachable.

That last condition is what makes the rest strict: the subscription telling the client which rooms exist is itself reachable only *through* the tunnel, so a client holding nothing but dead rooms cannot ask for live ones. Two obligations follow, and every change here serves one of them: never be down to one live room if it can be helped, and never let the client's own control traffic depend on the tunnel it is rebuilding.

| # | commit | files | depends on |
|---|--------|-------|------------|
| 1 | Dynamic room list: parse `##rooms`, persist failover rooms, feed them to olcRTC live | 4 | none |
| 2 | Windows TUN: keep the client's own traffic off its own tunnel | 1 | none |
| 3 | Desktop: refresh rooms after a handover, reconnect endlessly, pin olcRTC to the physical interface | 2 | 1, 2 |
| 4 | Refresh the room list on connect and before a deliberate stop | 1 | 1 |
| 5 | Android: plug the IPv6 leak and hand the failover room list to the runtime | 1 | 1; olcRTC 6 |
| 6 | Android: refresh the room list through the tunnel after a handover | 1 | 5; olcRTC 7 |

**Where to start.** Commit 2: with a TUN owning the default route, the desktop client could not establish a new session at all, because the provider call it needs to join a room was routed into the tunnel it was trying to build. The `##rooms` subscription header (commit 1) is backward compatible: a client that does not understand it ignores the line and uses the primary room.

**Dependencies outside this repository.** Commits 5 and 6 call `addFailoverRoom` / `clearFailoverRooms` / `setSessionListener` on the mobile runtime; those exist only with olcRTC commits 6 and 7 from https://github.com/openlibrecommunity/olcrtc/pull/152 built into the AAR, otherwise the Kotlin does not compile. Commits 2 and 3 hand the physical interface index to olcRTC as `OLCRTC_BIND_IFINDEX`; that only has an effect with olcRTC commit 3 from the same PR (without it the variable is set and ignored, behaviour unchanged). Commits 1, 3, 4 and the IPv6/logging parts are self-contained.

**Verification.** Rebased onto current `main` (1c86e87); all six apply without conflict. The resulting sources are identical to the working tree the desktop build and the Android APK in use were compiled from, whose test suite runs with the two added tests passing. Honest caveat: an isolated clean-room Gradle build could not be run on the machine at hand (it would not locate a Java 21 toolchain for a fresh daemon), so equivalence was established file by file rather than by a second build. Pre-existing failures at the base commit, untouched here: 3 in `DesktopProxyModeTest` (POSIX path separators on Windows).

**Related.** Transport: https://github.com/openlibrecommunity/olcrtc/pull/152. Server side: https://github.com/invdevv/olcwave/pull/14. Design notes (how a room id travels from a subscription into a live tunnel, what a handover does, what is still missing): https://github.com/WhimP990/olc-room-rotation-docs/tree/main/olcbox.

Happy to split, drop the Android half, or reshape anything to fit your conventions.
